### PR TITLE
perf: cut database round trips per sync call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.2 - 2026-08-09
 
 - Read the database clock once per transaction instead of once per step, and
   resolve the SQLite busy wait from configuration instead of querying the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Read the database clock once per transaction instead of once per step, and
+  resolve the SQLite busy wait from configuration instead of querying the
+  connection for it. A synchronous call now issues 49 database queries instead
+  of 66, which matters most on PostgreSQL and MySQL where every query is a
+  network round trip.
+- Apply every migration in the benchmark harness. It applied only the initial
+  migration, so the `state_revision` column added in 0.4.0 was missing, every
+  message failed at commit, and the synchronous benchmarks timed out.
+
 ## 0.5.1 - 2026-08-07
 
 - Restore the SQLite busy wait that a synchronous invocation suspends for its

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_objects (0.5.1)
+    solid_objects (0.5.2)
       actioncable (>= 8.0)
       actionpack (>= 8.0)
       actionview (>= 8.0)
@@ -373,7 +373,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  solid_objects (0.5.1)
+  solid_objects (0.5.2)
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b

--- a/benchmark/support.rb
+++ b/benchmark/support.rb
@@ -228,7 +228,9 @@ module SolidObjectsBenchmark
     # @rbs () -> void
     def migrate
       require_relative "../db/migrate/20260805000000_create_solid_objects_tables"
+      require_relative "../db/migrate/20260806000000_add_state_revision_to_solid_objects_instances"
       CreateSolidObjectsTables.new.migrate(:up)
+      AddStateRevisionToSolidObjectsInstances.new.migrate(:up)
     end
 
     # @rbs () -> void

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -41,6 +41,13 @@ scenario used four worker threads.
 | Synchronous latency | p50 1.8 ms, p95 25.6 ms, p99 156.2 ms |
 | Activation reuse | 98.0%, four activations for 200 messages |
 | Queries for one message turn | 29 |
+| Queries for one synchronous call | 49 |
+
+A synchronous call costs far more queries than a worker turn because the caller
+also registers or heartbeats its caller process, claims the activation, and
+observes the result. Query count, not query time, dominates synchronous latency
+on a networked database: measured locally against SQLite, database time is
+roughly 5% of a call and the remaining 95% is Ruby.
 
 The difference between the SQLite development result and the MySQL adoption
 result is why Solid Objects does not publish one latency promise. Network

--- a/lib/solid_objects/database_adapter.rb
+++ b/lib/solid_objects/database_adapter.rb
@@ -4,6 +4,9 @@ require "time"
 
 module SolidObjects
   class DatabaseAdapter
+    TRANSACTION_CLOCK = :solid_objects_transaction_clock
+    TRANSACTION_CLOCK_SCOPE = :solid_objects_transaction_clock_scope
+
     class << self
       # @rbs (untyped) -> DatabaseAdapter
       def for(connection)
@@ -46,10 +49,9 @@ module SolidObjects
 
     # @rbs () -> Time
     def database_now
-      value = with_connection do |connection|
-        connection.select_value("SELECT #{current_time_expression}")
-      end
-      value.is_a?(Time) ? value.utc : Time.parse("#{value} UTC").utc
+      return read_database_now unless ActiveSupport::IsolatedExecutionState[TRANSACTION_CLOCK_SCOPE]
+
+      ActiveSupport::IsolatedExecutionState[TRANSACTION_CLOCK] ||= read_database_now
     end
 
     # @rbs () { () -> untyped } -> untyped
@@ -70,7 +72,7 @@ module SolidObjects
         with_transaction_deadline(connection) do
           connection.transaction(requires_new: true) do
             configure_transaction_deadline(connection)
-            block.call
+            with_transaction_clock { block.call }
           end
         end
       end
@@ -90,6 +92,27 @@ module SolidObjects
     private
 
     attr_reader :connection_pool, :fixed_connection
+
+    # @rbs () { () -> untyped } -> untyped
+    def with_transaction_clock
+      return yield if ActiveSupport::IsolatedExecutionState[TRANSACTION_CLOCK_SCOPE]
+
+      ActiveSupport::IsolatedExecutionState[TRANSACTION_CLOCK_SCOPE] = true
+      begin
+        yield
+      ensure
+        ActiveSupport::IsolatedExecutionState[TRANSACTION_CLOCK_SCOPE] = false
+        ActiveSupport::IsolatedExecutionState[TRANSACTION_CLOCK] = nil
+      end
+    end
+
+    # @rbs () -> Time
+    def read_database_now
+      value = with_connection do |connection|
+        connection.select_value("SELECT #{current_time_expression}")
+      end
+      value.is_a?(Time) ? value.utc : Time.parse("#{value} UTC").utc
+    end
 
     # @rbs (untyped) { () -> untyped } -> untyped
     def with_transaction_deadline(_connection)

--- a/lib/solid_objects/database_adapters/sqlite.rb
+++ b/lib/solid_objects/database_adapters/sqlite.rb
@@ -71,7 +71,7 @@ module SolidObjects
         return yield unless busy_wait
 
         begin
-          connection.execute("PRAGMA busy_timeout = 0")
+          suspend_busy_wait(connection, busy_wait)
           yield
         ensure
           restore_busy_wait(connection, busy_wait)
@@ -80,13 +80,18 @@ module SolidObjects
 
       # @rbs (untyped) -> Hash[Symbol, untyped]?
       def restorable_busy_wait(connection)
-        pragma_timeout = connection.select_value("PRAGMA busy_timeout").to_i
-        return { pragma_timeout: } if pragma_timeout.positive?
-
         handler_timeout = configured_busy_handler_timeout(connection)
-        return nil unless handler_timeout
+        return { handler_timeout: } if handler_timeout
 
-        { pragma_timeout:, handler_timeout: }
+        pragma_timeout = connection.select_value("PRAGMA busy_timeout").to_i
+        return nil unless pragma_timeout.positive?
+
+        { pragma_timeout: }
+      end
+
+      # @rbs (untyped, Hash[Symbol, untyped]) -> void
+      def suspend_busy_wait(connection, _busy_wait)
+        connection.execute("PRAGMA busy_timeout = 0")
       end
 
       # @rbs (untyped, Hash[Symbol, untyped]) -> void

--- a/lib/solid_objects/database_adapters/sqlite.rb
+++ b/lib/solid_objects/database_adapters/sqlite.rb
@@ -71,7 +71,7 @@ module SolidObjects
         return yield unless busy_wait
 
         begin
-          suspend_busy_wait(connection, busy_wait)
+          connection.execute("PRAGMA busy_timeout = 0")
           yield
         ensure
           restore_busy_wait(connection, busy_wait)
@@ -87,11 +87,6 @@ module SolidObjects
         return nil unless pragma_timeout.positive?
 
         { pragma_timeout: }
-      end
-
-      # @rbs (untyped, Hash[Symbol, untyped]) -> void
-      def suspend_busy_wait(connection, _busy_wait)
-        connection.execute("PRAGMA busy_timeout = 0")
       end
 
       # @rbs (untyped, Hash[Symbol, untyped]) -> void

--- a/lib/solid_objects/version.rb
+++ b/lib/solid_objects/version.rb
@@ -1,5 +1,5 @@
 # rbs_inline: enabled
 
 module SolidObjects
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/sig/generated/lib/solid_objects/database_adapter.rbs
+++ b/sig/generated/lib/solid_objects/database_adapter.rbs
@@ -2,6 +2,10 @@
 
 module SolidObjects
   class DatabaseAdapter
+    TRANSACTION_CLOCK: ::Symbol
+
+    TRANSACTION_CLOCK_SCOPE: ::Symbol
+
     # @rbs (untyped) -> DatabaseAdapter
     def self.for: (untyped) -> DatabaseAdapter
 
@@ -41,6 +45,12 @@ module SolidObjects
     attr_reader connection_pool: untyped
 
     attr_reader fixed_connection: untyped
+
+    # @rbs () { () -> untyped } -> untyped
+    def with_transaction_clock: () { () -> untyped } -> untyped
+
+    # @rbs () -> Time
+    def read_database_now: () -> Time
 
     # @rbs (untyped) { () -> untyped } -> untyped
     def with_transaction_deadline: (untyped) { () -> untyped } -> untyped

--- a/sig/generated/lib/solid_objects/database_adapters/sqlite.rbs
+++ b/sig/generated/lib/solid_objects/database_adapters/sqlite.rbs
@@ -30,9 +30,6 @@ module SolidObjects
       def restorable_busy_wait: (untyped) -> Hash[Symbol, untyped]?
 
       # @rbs (untyped, Hash[Symbol, untyped]) -> void
-      def suspend_busy_wait: (untyped, Hash[Symbol, untyped]) -> void
-
-      # @rbs (untyped, Hash[Symbol, untyped]) -> void
       def restore_busy_wait: (untyped, Hash[Symbol, untyped]) -> void
 
       # @rbs (untyped) -> Integer?

--- a/sig/generated/lib/solid_objects/database_adapters/sqlite.rbs
+++ b/sig/generated/lib/solid_objects/database_adapters/sqlite.rbs
@@ -30,6 +30,9 @@ module SolidObjects
       def restorable_busy_wait: (untyped) -> Hash[Symbol, untyped]?
 
       # @rbs (untyped, Hash[Symbol, untyped]) -> void
+      def suspend_busy_wait: (untyped, Hash[Symbol, untyped]) -> void
+
+      # @rbs (untyped, Hash[Symbol, untyped]) -> void
       def restore_busy_wait: (untyped, Hash[Symbol, untyped]) -> void
 
       # @rbs (untyped) -> Integer?

--- a/test/integration/synchronous_invocation_test.rb
+++ b/test/integration/synchronous_invocation_test.rb
@@ -502,6 +502,56 @@ class SynchronousInvocationTest < ActiveSupport::TestCase
     release_sqlite_write_lock(lock) if lock
   end
 
+  test "sync does not re-read the SQLite busy wait it already knows how to restore" do
+    skip unless SolidObjects::Record.connection.adapter_name.match?(/sqlite/i)
+    CounterActor.ref("pragma-warm").increment
+    statements = []
+    subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+      statements << event.payload[:sql]
+    end
+
+    CounterActor.ref("pragma-warm").increment
+
+    ActiveSupport::Notifications.unsubscribe(subscription)
+    assert_empty statements.grep(/\APRAGMA busy_timeout\z/i),
+      "the configured busy wait is known without asking the database for it"
+    refute_empty statements.grep(/\APRAGMA busy_timeout = 0\z/i),
+      "the busy wait must still be suspended for the deadline"
+  end
+
+  test "a transaction reads the database clock once and shares the reading" do
+    readings = []
+    clock_reads = count_clock_reads do
+      SolidObjects.database_adapter.transaction do
+        3.times { readings << SolidObjects.database_adapter.database_now }
+      end
+    end
+
+    assert_equal 1, clock_reads
+    assert_equal 1, readings.uniq.length
+  end
+
+  test "the shared clock reading does not outlive its transaction" do
+    reads = count_clock_reads do
+      2.times do
+        SolidObjects.database_adapter.transaction { SolidObjects.database_adapter.database_now }
+      end
+    end
+
+    assert_equal 2, reads
+    assert_equal 1, count_clock_reads { SolidObjects.database_adapter.database_now }
+  end
+
+  test "sync stops re-reading the database clock for every step" do
+    reference = CounterActor.ref("clock-warm")
+    reference.increment
+
+    clock_reads = count_clock_reads { reference.increment }
+
+    assert_operator clock_reads, :<=, 4,
+      "a synchronous call should read the clock once per transaction, not once per step"
+  end
+
   test "sync discovers the configured SQLite busy wait it has to restore" do
     skip unless SolidObjects::Record.connection.adapter_name.match?(/sqlite/i)
 
@@ -851,6 +901,17 @@ class SynchronousInvocationTest < ActiveSupport::TestCase
     captured = Timeout.timeout(2) { result.pop }
     invocation.join
     captured
+  end
+
+  def count_clock_reads
+    reads = 0
+    subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+      reads += 1 if event.payload[:sql].match?(/STRFTIME|CURRENT_TIMESTAMP/i)
+    end
+    yield
+    reads
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription) if subscription
   end
 
   def process_write?(payload)


### PR DESCRIPTION
Reduces the database work in a synchronous call, and fixes the benchmark harness that made
any of this impossible to measure.

## The benchmark harness was broken

`benchmark/support.rb` applied only the initial migration, so the `state_revision` column
added in 0.4.0 was missing. Every message failed at commit with
`ActiveModel::UnknownAttributeError`, retried with backoff, and the synchronous benchmarks
timed out reporting `waiting_on=not_yet_available`. No benchmark in the repo could run.
Fixed by applying both migrations, as `test/database_test_helper.rb` already does.

## What the measurements showed

With the harness working, a warm synchronous call issues **66 queries** but spends only
0.6-1.4ms in SQL, so **92-95% of wall time is Ruby**, not the database. Two overheads
dominated the query count:

| Overhead | Queries per call |
| --- | ---: |
| `PRAGMA busy_timeout` read + write around every deadline-bound transaction | 28 |
| `SELECT STRFTIME` to read the database clock | 7 |

## What this changes

**The database clock is read once per transaction, not once per step.** Callers inside one
transaction now share a single reading, which is also the more correct semantic for lease
and fencing comparisons. Clock reads per synchronous call drop from 7 to 4, which is exactly
one per transaction: enqueue, claim, and two fenced transactions.

**The busy wait is resolved from the pool configuration instead of being queried.**
`configured_busy_handler_timeout` is pure Ruby, so checking it first removes the
`PRAGMA busy_timeout` read entirely. The pragma read now happens only when no timeout is
configured, which is the case where there is no Ruby busy handler to restore.

Net: **66 queries to 49 per synchronous call**, a 26% reduction. On SQLite that barely moves
p50, because SQL is 5% of the time. On PostgreSQL or MySQL, where every query is a network
round trip, query count *is* the latency: `docs/benchmarks.md` records a 60ms median MySQL
write, which is what 66 round trips costs.

## What this deliberately does not change

The remaining 14 `PRAGMA busy_timeout = 0` writes stay. Replacing them with a Ruby-level
`busy_handler(nil)` is measurably better but changes behaviour: with the pragma,
`BEGIN IMMEDIATE` succeeds under contention and the statement inside it fails; with the
handler cleared, `BEGIN IMMEDIATE` fails outright. Two existing contention tests assert
retry attempts against the processes table and fail under the second behaviour.

The prize is real and measured, so it is worth doing separately with proper scrutiny:

| Configuration | Queries/call | p95 | p99 |
| --- | ---: | ---: | ---: |
| Before this PR | 66 | 5.79ms | 33.80ms |
| This PR | 49 | 3.96ms | 34.85ms |
| Also removing the pragma writes | 35 | 2.47ms | **2.73ms** |

The p99 tail belongs entirely to those writes. This PR does not fix it.

## Effects

- **API**: none. No public signature changed.
- **Correctness**: one clock reading per transaction instead of several. Leases and fencing
  now compare against a consistent instant within a transaction, and each transaction still
  reads a fresh one. Suspension and restoration of the busy wait are unchanged.
- **Security**: none.
- **Migration**: none.
- **Compatibility**: the clock change is adapter-agnostic; the busy-wait change is SQLite
  only. If both a `timeout:` and an explicit `pragmas: {busy_timeout:}` are configured, the
  configured handler now wins on restore. That combination was already ambiguous.

## Validation

```bash
bundle exec rake
```

245 runs, 979 assertions, 0 failures. Standard Ruby, RuboCop, RBS, Steep, and Brakeman clean.
PostgreSQL and MySQL suites were not run locally because neither server is available; CI covers them.

## Tests

Four tests, each written failing first:

- a transaction reads the database clock once and shares the reading
- the shared clock reading does not outlive its transaction
- sync stops re-reading the database clock for every step
- sync does not re-read the SQLite busy wait it already knows how to restore
