### PR TITLE
docs: bring the roadmap up to 0.7.1

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,18 +17,25 @@
 - One-shot and recurring reminders with `:latest` or `:all` catch-up
 - Durable observable invalidations, scalar Turbo replacement, keyed ERB
   components, signed component locals, and authorized replace or morph refresh
+- Batched component refreshes: components sharing a signed `batch:` collapse to
+  one browser request per revision, served as HTML frames in a JSON envelope
+- Personalized state payload broadcasts computed per subscriber under that
+  subscriber's authorization context, fenced by actor revision
 - Reconciliation read APIs
 - Installation doctor, authorization reference, fit guide, and legacy-state
   migration cookbook
 - Handler Active Record write isolation, same-database commit actions, ambient
-  transaction rejection, adapter lock/query deadlines, structured sync timeout
-  diagnostics, and result recovery
+  transaction rejection, adapter lock/query deadlines, bounded SQLite lock
+  retries outside those deadlines, structured sync timeout diagnostics, and
+  result recovery
 - Bounded message/process pruning, actor-type opt-in instance expiration,
   graceful caller shutdown, committed state snapshots, and an opt-in Minitest
   helper
 - SQLite, PostgreSQL, and MySQL integration suites
 - Inline RBS generation/validation, Steep, Standard Ruby, Solid Queue's exact
   RuboCop policy, and a warning-free Brakeman scan
+- A JavaScript suite covering the browser modules, run in CI with Node's test
+  runner and jsdom, with every GitHub Actions reference pinned to a commit SHA
 
 ## Partially implemented
 
@@ -36,10 +43,17 @@
   role or run periodic maintenance automatically.
 - Wake-up strategy: in-process signaling plus durable polling and injection are
   implemented; PostgreSQL `LISTEN/NOTIFY` and optional Redis adapters are not.
+  Signaling cannot cross process boundaries, so a commit in a web process does
+  not wake a broadcast executor in a worker process; that delivery waits up to
+  `polling_interval`, 100 ms by default. This is the largest remaining term in
+  reactive update latency, and neither batching nor state payloads reduce it.
 - Realtime: scalar and dependency-driven keyed ERB component replacement or
   morphing, personalized refresh authorization, revision fencing, coalescing,
-  and reconnect convergence are implemented; application-directed Turbo
-  append intents are not.
+  reconnect convergence, batched refreshes, and personalized state payloads are
+  implemented; application-directed Turbo append intents are not. Batch
+  coalescing happens in the browser rather than the broadcast executor, so one
+  commit still sends one Action Cable message per changed observable even
+  though it costs one browser request.
 - Backpressure: mailbox/payload/state/result caps and fair yields exist;
   distributed per-actor rate limits and global admission control do not.
 - Administration: actor and dead-letter views plus policy hooks exist; richer
@@ -51,7 +65,8 @@
 
 1. Add automatic supervisor role replacement and periodic dead-process cleanup.
 2. Add PostgreSQL notification and optional Redis wake-up adapters with latency
-   benchmarks and polling-race tests.
+   benchmarks and polling-race tests, removing the cross-process polling delay
+   rather than shrinking it with a smaller `polling_interval`.
 3. Add result lookup by request ID and broader deadlock retry classification.
 4. Add scheduled retention and stale-process maintenance.
 5. Add database/server-version checks and MySQL InnoDB verification at boot.
@@ -61,7 +76,9 @@
 8. Expand security scanning and run compatibility CI across supported Rails and
    Ruby versions.
 9. Benchmark all workloads under documented hardware/database settings and
-   publish adapter-specific adoption measurements.
+   publish adapter-specific adoption measurements. Throughput, synchronous
+   latency, query counts, and the three reactive delivery paths are measured on
+   SQLite; adapter-specific and end-to-end browser measurements are not.
 
 No production-ready claim should be made until these hardening milestones have
 operational soak evidence.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,8 +34,9 @@
 - SQLite, PostgreSQL, and MySQL integration suites
 - Inline RBS generation/validation, Steep, Standard Ruby, Solid Queue's exact
   RuboCop policy, and a warning-free Brakeman scan
-- A JavaScript suite covering the browser modules, run in CI with Node's test
-  runner and jsdom, with every GitHub Actions reference pinned to a commit SHA
+- A JavaScript suite covering the state payload and batched refresh browser
+  modules, run in CI with Node's test runner and jsdom, with every GitHub
+  Actions reference pinned to a commit SHA
 
 ## Partially implemented
 
@@ -58,6 +59,9 @@
   distributed per-actor rate limits and global admission control do not.
 - Administration: actor and dead-letter views plus policy hooks exist; richer
   filtering, audit records, and bulk-safe tools do not.
+- Browser module coverage: the state payload and batched refresh modules have
+  JavaScript tests; `component_refresh.js`, which drives individual morph
+  refreshes, does not.
 - Outboxes use portable status rows with polling indexes; future versions may
   introduce narrow ready/claimed membership tables for very large outboxes.
 


### PR DESCRIPTION
Documentation only. The roadmap still described the delivery story as of 0.5.0, so anyone reading
it today would conclude that batching and state payloads do not exist.

## Recorded as implemented

- **Batched component refreshes**: components sharing a signed `batch:` collapse to one browser
  request per revision, served as HTML frames in a JSON envelope.
- **Personalized state payload broadcasts**: computed per subscriber under that subscriber's
  authorization context, fenced by actor revision.
- **The JavaScript suite**: browser modules covered in CI with Node's test runner and jsdom, with
  every GitHub Actions reference pinned to a commit SHA.
- **Bounded SQLite lock retries outside synchronous deadlines**, folded into the existing
  correctness bullet.

## Corrected rather than just added

**The realtime bullet** now states plainly that batch coalescing happens in the browser, not the
broadcast executor, so one commit still sends one Action Cable message per changed observable
even though it costs one browser request. That distinction was implicit in the PR that shipped
batching and deserves to be visible where people evaluate the design.

**Milestone 9** no longer reads as untouched. Throughput, synchronous latency, query counts, and
the three reactive delivery paths are measured on SQLite; adapter-specific and end-to-end browser
measurements are not, and the milestone now says exactly that instead of implying either
everything or nothing is done.

## The part worth reading

The wake-up bullet now records a measured fact that was not written down anywhere:

> Signaling cannot cross process boundaries, so a commit in a web process does not wake a
> broadcast executor in a worker process; that delivery waits up to `polling_interval`, 100 ms by
> default. This is the largest remaining term in reactive update latency, and neither batching nor
> state payloads reduce it.

`WakeUp` is a plain in-process `Thread::ConditionVariable` and `polling_interval` still defaults
to `0.1`. Everything shipped in 0.6.0 and 0.7.0 cut the number of requests, three to one and then
one to zero, but none of it touches that polling delay. Milestone 2 is reworded to say it should
remove the delay rather than shrink it with a smaller interval.

## Not included

No version bump. This changes no code and does not warrant a gem release; it can ride along with
whatever ships next.

## Validation

```bash
bundle exec rake
```

271 runs, 1055 assertions, 0 failures, with Standard Ruby, RuboCop, RBS, Steep, and Brakeman
clean. No source files changed.
