### PR TITLE
fix: render batched components as HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.7.2 - 2026-08-09
 
 - Render batched component partials as HTML regardless of the request format.
   The batch endpoint is requested with a JSON `Accept` header, so Rails looked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- Render batched component partials as HTML regardless of the request format.
+  The batch endpoint is requested with a JSON `Accept` header, so Rails looked
+  for JSON templates, raised `ActionView::MissingTemplate`, and the batch
+  returned 404 for applications whose components are ordinary
+  `.html.erb` partials. The outer response is still JSON. Single-component
+  refresh was never affected and is unchanged.
+- Pass `registrations:` to `component_authorization_context`: one registration
+  for a single refresh, all of them for a batch, so applications no longer have
+  to inspect `params[:tokens]`. Callbacks accepting only `controller:` keep
+  working unchanged.
+
 ## 0.7.1 - 2026-08-09
 
 - Retry a contended SQLite write outside a synchronous deadline. Asynchronous

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_objects (0.7.1)
+    solid_objects (0.7.2)
       actioncable (>= 8.0)
       actionpack (>= 8.0)
       actionview (>= 8.0)
@@ -373,7 +373,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  solid_objects (0.7.1)
+  solid_objects (0.7.2)
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b

--- a/app/controllers/solid_objects/components_controller.rb
+++ b/app/controllers/solid_objects/components_controller.rb
@@ -143,13 +143,21 @@ module SolidObjects
       callable.call(controller: self, registrations:)
     end
 
+    # A lambda answers `parameters` directly; a callable object answers it
+    # through its `call` method.
     # @rbs (untyped) -> bool
     def accepts_registrations?(callable)
-      return false unless callable.respond_to?(:parameters)
-
-      callable.parameters.any? do |type, name|
+      callable_parameters(callable).any? do |type, name|
         type == :keyrest || (%i[key keyreq].include?(type) && name == :registrations)
       end
+    end
+
+    # @rbs (untyped) -> Array[[ Symbol, Symbol ]]
+    def callable_parameters(callable)
+      return callable.parameters if callable.respond_to?(:parameters)
+      return callable.method(:call).parameters if callable.respond_to?(:call)
+
+      []
     end
 
     # @rbs (ComponentRegistration) -> Hash[Symbol, untyped]

--- a/app/controllers/solid_objects/components_controller.rb
+++ b/app/controllers/solid_objects/components_controller.rb
@@ -43,10 +43,7 @@ module SolidObjects
         return head :conflict
       end
 
-      authorization_context = SolidObjects
-        .configuration
-        .component_authorization_context
-        .call(controller: self)
+      authorization_context = component_authorization_context(registrations)
       frames = registrations.map do |registration|
         rendered = ComponentRenderer.new(
           snapshot:,
@@ -112,10 +109,7 @@ module SolidObjects
         return head :conflict
       end
 
-      authorization_context = SolidObjects
-        .configuration
-        .component_authorization_context
-        .call(controller: self)
+      authorization_context = component_authorization_context([ registration ])
       rendered = ComponentRenderer.new(
         snapshot:,
         registration:,
@@ -136,6 +130,26 @@ module SolidObjects
       InvalidComponentToken
       payload[:outcome] = "invalid_token"
       head :bad_request
+    end
+
+    # Callbacks written before batching accept only `controller:`. Those keep
+    # working; a callback that also accepts `registrations:` receives one
+    # registration for a single refresh and all of them for a batch.
+    # @rbs (Array[ComponentRegistration]) -> untyped
+    def component_authorization_context(registrations)
+      callable = SolidObjects.configuration.component_authorization_context
+      return callable.call(controller: self) unless accepts_registrations?(callable)
+
+      callable.call(controller: self, registrations:)
+    end
+
+    # @rbs (untyped) -> bool
+    def accepts_registrations?(callable)
+      return false unless callable.respond_to?(:parameters)
+
+      callable.parameters.any? do |type, name|
+        type == :keyrest || (%i[key keyreq].include?(type) && name == :registrations)
+      end
     end
 
     # @rbs (ComponentRegistration) -> Hash[Symbol, untyped]

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -290,6 +290,20 @@ commonly resolve it to `Current.user`:
 configuration.component_authorization_context = ->(controller:) { Current.user }
 ```
 
+A callback may also accept `registrations:`, which receives one registration for
+a single component refresh and every registration in the group for a batch
+refresh. This avoids decoding `params[:tokens]` by hand when a policy depends on
+which components were requested:
+
+```ruby
+configuration.component_authorization_context = lambda do |controller:, registrations:|
+  Current.user if registrations.all? { |registration| registration.component_key == controller.session[:seat] }
+end
+```
+
+Callbacks that accept only `controller:` continue to work; the extra keyword is
+passed only to callables that declare it.
+
 The three contexts are intentionally different:
 
 | Boundary | Authorization context |

--- a/lib/solid_objects/component_renderer.rb
+++ b/lib/solid_objects/component_renderer.rb
@@ -32,6 +32,7 @@ module SolidObjects
       )
       view_context.render(
         partial: default_partial,
+        formats: [ :html ],
         locals: registration.locals.transform_keys(&:to_sym).merge(
           actor:,
           authorization_context:,

--- a/lib/solid_objects/version.rb
+++ b/lib/solid_objects/version.rb
@@ -1,5 +1,5 @@
 # rbs_inline: enabled
 
 module SolidObjects
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end

--- a/sig/generated/controllers/solid_objects/components_controller.rbs
+++ b/sig/generated/controllers/solid_objects/components_controller.rbs
@@ -27,8 +27,13 @@ module SolidObjects
     # @rbs (Array[ComponentRegistration]) -> untyped
     def component_authorization_context: (Array[ComponentRegistration]) -> untyped
 
+    # A lambda answers `parameters` directly; a callable object answers it
+    # through its `call` method.
     # @rbs (untyped) -> bool
     def accepts_registrations?: (untyped) -> bool
+
+    # @rbs (untyped) -> Array[[ Symbol, Symbol ]]
+    def callable_parameters: (untyped) -> Array[[ Symbol, Symbol ]]
 
     # @rbs (ComponentRegistration) -> Hash[Symbol, untyped]
     def registration_payload: (ComponentRegistration) -> Hash[Symbol, untyped]

--- a/sig/generated/controllers/solid_objects/components_controller.rbs
+++ b/sig/generated/controllers/solid_objects/components_controller.rbs
@@ -21,6 +21,15 @@ module SolidObjects
     # @rbs (Hash[Symbol, untyped]) -> void
     def refresh: (Hash[Symbol, untyped]) -> void
 
+    # Callbacks written before batching accept only `controller:`. Those keep
+    # working; a callback that also accepts `registrations:` receives one
+    # registration for a single refresh and all of them for a batch.
+    # @rbs (Array[ComponentRegistration]) -> untyped
+    def component_authorization_context: (Array[ComponentRegistration]) -> untyped
+
+    # @rbs (untyped) -> bool
+    def accepts_registrations?: (untyped) -> bool
+
     # @rbs (ComponentRegistration) -> Hash[Symbol, untyped]
     def registration_payload: (ComponentRegistration) -> Hash[Symbol, untyped]
 

--- a/test/integration/component_batch_controller_test.rb
+++ b/test/integration/component_batch_controller_test.rb
@@ -10,6 +10,21 @@ require_relative "../../app/controllers/solid_objects/components_controller"
 class ComponentBatchControllerTest < ActionController::TestCase
   tests SolidObjects::ComponentsController
 
+  class RegistrationAwareResolver
+    attr_reader :received
+
+    def call(controller:, registrations:)
+      @received = registrations
+      controller.request.headers["HTTP_X_VIEWER"]
+    end
+  end
+
+  class ControllerOnlyResolver
+    def call(controller:)
+      controller.request.headers["HTTP_X_VIEWER"]
+    end
+  end
+
   class PlaymatRoom < SolidObjects::Actor
     actor_type "batch-controller-playmat"
 
@@ -206,6 +221,27 @@ class ComponentBatchControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal %w[player], received.map(&:component_name)
+  end
+
+  test "a callable object requiring registrations receives them" do
+    resolver = RegistrationAwareResolver.new
+    SolidObjects.configuration.component_authorization_context = resolver
+    registrations = issue(player: %w[player], controls: %w[controls])
+
+    get_batch(registrations)
+
+    assert_response :success
+    assert_equal %w[player controls], resolver.received.map(&:component_name)
+  end
+
+  test "a callable object accepting only controller keeps working" do
+    SolidObjects.configuration.component_authorization_context = ControllerOnlyResolver.new
+    registrations = issue(player: %w[player])
+
+    get_batch(registrations)
+
+    assert_response :success
+    assert_includes json_body.fetch("frames").first.fetch("html"), "data-player"
   end
 
   test "single component refresh still renders HTML" do

--- a/test/integration/component_batch_controller_test.rb
+++ b/test/integration/component_batch_controller_test.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require "database_test_helper"
+require "action_controller"
+require "action_controller/test_case"
+require "action_view"
+require "action_view/testing/resolvers"
+require_relative "../../app/controllers/solid_objects/components_controller"
+
+class ComponentBatchControllerTest < ActionController::TestCase
+  tests SolidObjects::ComponentsController
+
+  class PlaymatRoom < SolidObjects::Actor
+    actor_type "batch-controller-playmat"
+
+    attribute :player, default: "alice"
+    attribute :controls, default: -> { %w[untap draw] }
+    attribute :library, default: -> { %w[Island] }
+
+    observable :player
+    observable :controls
+    observable :library
+
+    def seat(player:)
+      self.player = player
+    end
+  end
+
+  setup do
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @routes.draw do
+      get "components", to: "solid_objects/components#show"
+      get "components/batch", to: "solid_objects/components#batch"
+    end
+    @controller.prepend_view_path(
+      ActionView::FixtureResolver.new(
+        "actors/component_batch_controller_test/playmat_room/_player.html.erb" =>
+          "<p data-player><%= actor.player %></p>",
+        "actors/component_batch_controller_test/playmat_room/_controls.html.erb" =>
+          "<ul><% actor.controls.each do |control| %><li><%= control %></li><% end %></ul>",
+        "actors/component_batch_controller_test/playmat_room/_library.html.erb" =>
+          "<div data-viewer=\"<%= authorization_context %>\" data-seat=\"<%= seat %>\"><%= actor.library.join(\",\") %></div>"
+      )
+    )
+    SolidObjects.configuration.stream_signing_secret = "batch-controller-secret"
+    SolidObjects.configuration.component_authorization_context = lambda do |controller:|
+      controller.request.headers["HTTP_X_VIEWER"]
+    end
+    PlaymatRoom.ensure_registered!
+  end
+
+  test "renders an HTML ERB component through the JSON batch endpoint" do
+    registrations = issue(player: %w[player])
+
+    get_batch(registrations)
+
+    assert_response :success
+    assert_equal "application/json", response.media_type
+    frame = json_body.fetch("frames").first
+    assert_includes frame.fetch("html"), "data-player"
+    assert_includes frame.fetch("html"), "alice"
+  end
+
+  test "renders several components in one batch" do
+    registrations = issue(player: %w[player], controls: %w[controls])
+
+    get_batch(registrations)
+
+    assert_response :success
+    frames = json_body.fetch("frames")
+    assert_equal 2, frames.length
+    assert_includes frames.first.fetch("html"), "data-player"
+    assert_includes frames.last.fetch("html"), "<li>untap</li>"
+  end
+
+  test "renders a component with locals and dependencies" do
+    registrations = issue(library: %w[library])
+
+    get_batch(registrations)
+
+    assert_response :success
+    html = json_body.fetch("frames").first.fetch("html")
+    assert_includes html, %(data-viewer="alice")
+    assert_includes html, %(data-seat="north")
+    assert_includes html, "Island"
+  end
+
+  test "the request format stays JSON while partials render as HTML" do
+    registrations = issue(player: %w[player])
+
+    get_batch(registrations)
+
+    assert_equal "application/json", response.media_type
+    assert_includes json_body.fetch("frames").first.fetch("html"), "<turbo-frame"
+  end
+
+  test "carries target, revision, and refresh method for each frame" do
+    registrations = issue(player: %w[player], controls: %w[controls])
+
+    get_batch(registrations)
+
+    frames = json_body.fetch("frames")
+    assert_equal registrations.map(&:dom_id), frames.map { |frame| frame.fetch("target") }
+    assert(frames.all? { |frame| frame.fetch("refresh_method") == "morph" })
+    assert(frames.all? { |frame| frame.fetch("revision").match?(/\A\d+:\d+\z/) })
+  end
+
+  test "returns not found for a component with no partial" do
+    registrations = issue(missing: %w[player])
+
+    get_batch(registrations)
+
+    assert_response :not_found
+  end
+
+  test "returns bad request for an invalid token" do
+    @request.headers["HTTP_X_VIEWER"] = "alice"
+    @request.headers["Accept"] = "application/json"
+    get :batch, params: { tokens: [ "forged" ], instance_id: 1, revision: 1 }
+
+    assert_response :bad_request
+  end
+
+  test "returns forbidden when the viewer is not authorized" do
+    SolidObjects.configuration.authorize_query = lambda do |**arguments|
+      arguments.fetch(:authorization_context) == "alice"
+    end
+    registrations = issue(player: %w[player])
+
+    get_batch(registrations, viewer: "mallory")
+
+    assert_response :forbidden
+  end
+
+  test "returns conflict for a revision newer than committed state" do
+    registrations = issue(player: %w[player])
+    @request.headers["HTTP_X_VIEWER"] = "alice"
+    @request.headers["Accept"] = "application/json"
+
+    get :batch, params: {
+      tokens: registrations.map(&:token),
+      instance_id: registrations.first.instance_id + 1,
+      revision: registrations.first.revision
+    }
+
+    assert_response :conflict
+  end
+
+  test "the authorization callback receives every registration in a batch" do
+    received = nil
+    SolidObjects.configuration.component_authorization_context = lambda do |controller:, registrations:|
+      received = registrations
+      controller.request.headers["HTTP_X_VIEWER"]
+    end
+    registrations = issue(player: %w[player], controls: %w[controls])
+
+    get_batch(registrations)
+
+    assert_response :success
+    assert_equal %w[player controls], received.map(&:component_name)
+  end
+
+  test "the authorization callback receives one registration for a single refresh" do
+    received = nil
+    SolidObjects.configuration.component_authorization_context = lambda do |controller:, registrations:|
+      received = registrations
+      controller.request.headers["HTTP_X_VIEWER"]
+    end
+    registration = issue(player: %w[player]).first
+    @request.headers["HTTP_X_VIEWER"] = "alice"
+
+    get :show, params: {
+      token: registration.token,
+      instance_id: registration.instance_id,
+      revision: registration.revision
+    }
+
+    assert_response :success
+    assert_equal %w[player], received.map(&:component_name)
+  end
+
+  test "a callback accepting only controller keeps working" do
+    seen = 0
+    SolidObjects.configuration.component_authorization_context = lambda do |controller:|
+      seen += 1
+      controller.request.headers["HTTP_X_VIEWER"]
+    end
+    registrations = issue(player: %w[player], controls: %w[controls])
+
+    get_batch(registrations)
+
+    assert_response :success
+    assert_equal 1, seen
+    assert_includes json_body.fetch("frames").first.fetch("html"), "data-player"
+  end
+
+  test "a callback accepting keyword splat receives registrations" do
+    received = nil
+    SolidObjects.configuration.component_authorization_context = lambda do |**arguments|
+      received = arguments[:registrations]
+      arguments.fetch(:controller).request.headers["HTTP_X_VIEWER"]
+    end
+    registrations = issue(player: %w[player])
+
+    get_batch(registrations)
+
+    assert_response :success
+    assert_equal %w[player], received.map(&:component_name)
+  end
+
+  test "single component refresh still renders HTML" do
+    registration = issue(player: %w[player]).first
+    @request.headers["HTTP_X_VIEWER"] = "alice"
+
+    get :show, params: {
+      token: registration.token,
+      instance_id: registration.instance_id,
+      revision: registration.revision
+    }
+
+    assert_response :success
+    assert_equal "text/html", response.media_type
+    assert_includes response.body, "data-player"
+  end
+
+  private
+
+  def reference
+    PlaymatRoom.ref("table")
+  end
+
+  def issue(**components)
+    snapshot = SolidObjects::ActorSnapshot.new(reference)
+    components.map do |component_name, dependencies|
+      SolidObjects::ComponentRegistration.issue(
+        reference:,
+        component_name: component_name.to_s,
+        component_key: nil,
+        dependencies:,
+        locals: (component_name.to_s == "library") ? { seat: "north" } : {},
+        refresh_method: "morph",
+        snapshot:,
+        refresh_path: "/components",
+        batch: "playmat"
+      )
+    end
+  end
+
+  # The browser module requests the batch with a JSON Accept header, which is
+  # what makes Rails look for JSON partials.
+  def get_batch(registrations, viewer: "alice")
+    @request.headers["HTTP_X_VIEWER"] = viewer
+    @request.headers["Accept"] = "application/json"
+    get :batch, params: {
+      tokens: registrations.map(&:token),
+      instance_id: registrations.first.instance_id,
+      revision: registrations.first.revision
+    }
+  end
+
+  def json_body
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
Fixes the batch rendering bug you reported, and improves the authorization API for batching.

## The bug

Confirmed exactly as reported. The browser module requests the batch with `Accept: application/json`,
so Rails resolved component partials against the JSON format, raised `ActionView::MissingTemplate`,
and the controller converted that into `UnknownComponent` and a 404. Any application whose
components are ordinary `.html.erb` partials, which is all of them, got a 404 for every batch.

Worth noting how it hid: my first version of the regression test passed. `ActionController::TestCase`
defaults the request format to HTML, so the test did not reproduce what the browser actually sends.
Adding the `Accept: application/json` header reproduced the 404 with an empty body immediately. The
tests now set that header, which is what makes them regression tests rather than decoration.

## The fix

`ComponentRenderer` renders partials with an explicit `formats: [ :html ]`. The outer response is
still JSON with the same envelope. Applications do not need `.json.erb` copies of anything.

Fixing it in the renderer rather than the batch action means both endpoints resolve templates the
same way, so a future caller cannot reintroduce the bug by rendering components under a different
format.

Single-component refresh sends an HTML `Accept` header and was never affected; a test asserts it
still returns `text/html` with rendered markup.

## Authorization API

`component_authorization_context` now receives `registrations:` alongside `controller:` — one
registration for a single refresh, all of them for a batch — so applications no longer inspect
`params[:tokens]` by hand:

```ruby
configuration.component_authorization_context = lambda do |controller:, registrations:|
  Current.user if registrations.all? { |r| r.component_key == controller.session[:seat] }
end
```

**Backward compatible.** The controller inspects the callable's parameters and passes the extra
keyword only to callables that declare it, either as `registrations:` or a keyword splat. A
callback accepting only `controller:` is called exactly as before. Tests cover all three shapes.

## Unchanged behaviour, all asserted

`refresh_method`, target IDs, per-frame revisions, authorization, and stale-revision handling are
untouched. Missing component still 404, invalid token still 400, unauthorized still 403, newer
requested revision still 409.

## Tests

14 controller tests: an HTML ERB component through the JSON endpoint, several components in one
batch, a component with locals and dependencies, HTML rendering while the request format is JSON,
frame metadata, the four error cases, the three authorization callback shapes, and single-component
refresh still rendering HTML.

## Upgrade notes

No database change, no migration, no initializer regeneration, no token format change. Applications
on 0.7.0 or 0.7.1 using `batch:` should upgrade, since batching returns 404 for HTML partials on
those versions. No application code change is required; adopting `registrations:` is optional.

## Validation

```bash
bundle exec rake   # 285 runs, 1098 assertions, 0 failures
npm test           # 23 pass, 0 fail
```

Standard Ruby, RuboCop, RBS, Steep, and Brakeman clean. Version bumped to 0.7.2.
