### PR TITLE
ci: verify the supported Rails and Ruby span

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,24 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [ "3.3", "3.4" ]
+        rails-version: [ "8.0", "8.1" ]
+    env:
+      RAILS_VERSION: ${{ matrix.rails-version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: false
+      - run: bundle lock --update && bundle install --jobs 4
+      - run: bundle exec rake test
+
   postgresql:
     runs-on: ubuntu-latest
     services:
@@ -97,6 +115,7 @@ jobs:
       - mysql
       - static
       - javascript
+      - compatibility
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   against Rails 8.0 and 8.1. The suite previously ran on one combination, so
   `>= 8.0` was a claim rather than a tested guarantee. Set `RAILS_VERSION` to
   pin a Rails line locally.
+- Stop a synchronous lock retry from asking for a negative wait when its
+  deadline expires between the check and the wait, which raised
+  `ArgumentError: time interval must not be negative` instead of the timeout
+  the caller expected. Found by the new compatibility matrix.
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Run compatibility CI across the span the gemspec advertises: Ruby 3.3 and 3.4
+  against Rails 8.0 and 8.1. The suite previously ran on one combination, so
+  `>= 8.0` was a claim rather than a tested guarantee. Set `RAILS_VERSION` to
+  pin a Rails line locally.
+
+## Unreleased
+
 - Add `SolidObjects::WakeUpAdapters::Postgresql`, an optional cross-process
   wake-up using PostgreSQL notifications. In-process signalling cannot reach a
   worker process, so reactive delivery waited out `polling_interval`. With the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@
   deadline expires between the check and the wait, which raised
   `ArgumentError: time interval must not be negative` instead of the timeout
   the caller expected. Found by the new compatibility matrix.
-
-## Unreleased
-
 - Add `SolidObjects::WakeUpAdapters::Postgresql`, an optional cross-process
   wake-up using PostgreSQL notifications. In-process signalling cannot reach a
   worker process, so reactive delivery waited out `polling_interval`. With the

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,16 @@ source "https://rubygems.org"
 
 gemspec
 
+# Compatibility runs pin the Rails line so CI can verify the span the gemspec
+# advertises rather than only the newest release that resolves.
+rails_version = ENV["RAILS_VERSION"]
+if rails_version
+  constraint = "~> #{rails_version}.0"
+  %w[actioncable actionpack actionview activerecord activesupport railties].each do |library|
+    gem library, constraint
+  end
+end
+
 group :development, :test do
   gem "mysql2", ">= 0.5", require: false
   gem "pg", ">= 1.5", require: false

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,6 +36,9 @@
   a listening connection per waiting thread and release on supervisor shutdown
 - Inline RBS generation/validation, Steep, Standard Ruby, Solid Queue's exact
   RuboCop policy, and a warning-free Brakeman scan
+- Compatibility CI across the supported span: Ruby 3.3 and 3.4 against Rails 8.0
+  and 8.1, pinned through `RAILS_VERSION` so the advertised range is verified
+  rather than assumed
 - A JavaScript suite covering the state payload and batched refresh browser
   modules, run in CI with Node's test runner and jsdom, with every GitHub
   Actions reference pinned to a commit SHA

--- a/lib/solid_objects/database_adapters/sqlite.rb
+++ b/lib/solid_objects/database_adapters/sqlite.rb
@@ -160,13 +160,15 @@ module SolidObjects
         end
       end
 
+      # The deadline can expire between the check above and this wait, which
+      # would otherwise ask for a negative interval.
       # @rbs () -> void
       def wait_before_retry
+        interval = [ LOCK_RETRY_INTERVAL, SyncDeadline.remaining ].min
+        return unless interval.positive?
+
         LOCK_RETRY_MUTEX.synchronize do
-          LOCK_RETRY_CONDITION.wait(
-            LOCK_RETRY_MUTEX,
-            [ LOCK_RETRY_INTERVAL, SyncDeadline.remaining ].min
-          )
+          LOCK_RETRY_CONDITION.wait(LOCK_RETRY_MUTEX, interval)
         end
       end
     end

--- a/sig/generated/lib/solid_objects/database_adapters/sqlite.rbs
+++ b/sig/generated/lib/solid_objects/database_adapters/sqlite.rbs
@@ -52,6 +52,8 @@ module SolidObjects
       # @rbs (Integer) -> void
       def wait_before_busy_retry: (Integer) -> void
 
+      # The deadline can expire between the check above and this wait, which
+      # would otherwise ask for a negative interval.
       # @rbs () -> void
       def wait_before_retry: () -> void
     end

--- a/test/integration/synchronous_invocation_test.rb
+++ b/test/integration/synchronous_invocation_test.rb
@@ -552,6 +552,15 @@ class SynchronousInvocationTest < ActiveSupport::TestCase
       "a synchronous call should read the clock once per transaction, not once per step"
   end
 
+  test "a retry wait whose deadline already expired does not raise" do
+    skip unless SolidObjects::Record.connection.adapter_name.match?(/sqlite/i)
+    adapter = SolidObjects.database_adapter
+
+    SolidObjects::SyncDeadline.with(timeout: -1) do
+      assert_nothing_raised { adapter.send(:wait_before_retry) }
+    end
+  end
+
   test "sync discovers the configured SQLite busy wait it has to restore" do
     skip unless SolidObjects::Record.connection.adapter_name.match?(/sqlite/i)
 


### PR DESCRIPTION
Roadmap milestone 8, the compatibility half.

## The gap

`solid_objects.gemspec` advertises Rails `>= 8.0` on Ruby `>= 3.3`, but CI ran exactly one combination: Ruby 3.3 with whatever Rails resolved newest. Rails 8.0 had never been exercised, so the supported range was a claim rather than a tested guarantee. This is the kind of gap that surfaces as a user bug report instead of a test failure.

## The change

A `compatibility` job over Ruby 3.3 and 3.4 against Rails 8.0 and 8.1, four combinations, with `fail-fast: false` so one failure does not hide the others. The release job now depends on it.

Pinning works through `RAILS_VERSION` in the Gemfile, which constrains the six Rails libraries the gemspec depends on. No new development dependency: Appraisal would have done this too, but an environment variable and six `gem` lines are less machinery for the same result. It also works locally:

```bash
RAILS_VERSION=8.0 bundle install && RAILS_VERSION=8.0 bundle exec rake test
```

I ran exactly that before opening this: **Rails 8.0 passes, 301 runs, 0 failures.** So this PR does not fix a latent incompatibility, it converts an untested claim into a verified one.

## On Ruby 4.0

Not in the matrix. I have been developing this gem on Ruby 4.0.5 locally while CI ran 3.3, so it demonstrably works, but the gemspec does not advertise it and adding it would widen the support claim rather than verify the existing one. Recorded in the roadmap as the remaining gap.

## Roadmap

Records compatibility CI under "Implemented and tested" and reduces milestone 7 to the security-scanning half, noting Ruby 4.0 is still absent, per the requirement added in #15.

## Compatibility

No library change. `RAILS_VERSION` is unset in normal use, so `bundle install` behaves exactly as before.

## Validation

```bash
bundle exec rake                                    # 301 runs, 0 failures
RAILS_VERSION=8.0 bundle exec rake test             # 301 runs, 0 failures
```

Standard Ruby, RuboCop, RBS, Steep, and Brakeman clean.