### PR TITLE
docs: restore the compatibility CI milestone wording

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -85,8 +85,8 @@
 5. Add Turbo append intents and expand reconnect coverage in a full browser.
 6. Add distributed rate limits, global admission hooks, and cache-capacity
    eviction.
-7. Expand security scanning and run compatibility CI across supported Rails and
-   Ruby versions.
+7. Expand security scanning. Compatibility CI across supported Rails and Ruby
+   versions is implemented; Ruby 4.0 is not yet in the matrix.
 8. Benchmark all workloads under documented hardware/database settings and
    publish adapter-specific adoption measurements. Throughput, synchronous
    latency, query counts, and the three reactive delivery paths are measured on


### PR DESCRIPTION
Milestone 7 on main claims compatibility CI is still outstanding. It shipped in #17 and runs on every build, four cells, including the v0.8.0 release job.

I wrote this correction in #17 and then reverted it myself: rebasing #16 onto main resolved the `CHANGELOG.md` conflicts but silently restored my branch's older copy of `docs/roadmap.md`. The "Implemented and tested" entry survived; only the milestone line regressed.

Two lines, restoring what #17 said, including that Ruby 4.0 is still absent from the matrix.

```bash
bundle exec rake   # 312 runs, 0 failures
```

Documentation only. No version bump.