### PR TITLE
chore: prepare 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.9.0 - 2026-08-10
 
 - Add a browser test suite running the refresh modules against real Chromium and
   a real Turbo build, covering `component_refresh.js`, which previously had no

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_objects (0.8.0)
+    solid_objects (0.9.0)
       actioncable (>= 8.0)
       actionpack (>= 8.0)
       actionview (>= 8.0)
@@ -380,7 +380,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  solid_objects (0.8.0)
+  solid_objects (0.9.0)
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,0 +1,91 @@
+# Local testing
+
+The default suite runs against SQLite and needs nothing extra:
+
+```bash
+bundle exec rake
+```
+
+Everything below is optional. Each adapter and each optional service skips its
+tests when the service is absent, so a missing container degrades coverage
+rather than breaking the run. That is convenient, and it is also a trap: a
+skipped test looks identical to a passing one in the summary line. Check the
+skip count when a change touches an adapter.
+
+## PostgreSQL
+
+```bash
+brew services start postgresql@17
+createuser -h 127.0.0.1 -s solid_objects
+psql -h 127.0.0.1 -d postgres -c "ALTER USER solid_objects WITH PASSWORD 'solid_objects';"
+createdb -h 127.0.0.1 -O solid_objects solid_objects_test
+
+SOLID_OBJECTS_DATABASE_URL=postgresql://solid_objects:solid_objects@127.0.0.1:5432/solid_objects_test \
+  bundle exec rake test
+```
+
+Running this locally is worth the setup: it is what caught the PostgreSQL
+version comparison reading a packed integer, where `170010` compared greater
+than any minimum and made the check useless on the adapter it mattered most for.
+
+## MySQL and Redis in Docker
+
+These use non-default ports so they cannot collide with a MySQL or Redis that
+another project is already running:
+
+```bash
+docker run -d --name so-mysql -p 3307:3306 \
+  -e MYSQL_ROOT_PASSWORD=solid_objects \
+  -e MYSQL_DATABASE=solid_objects_test \
+  -e MYSQL_USER=solid_objects \
+  -e MYSQL_PASSWORD=solid_objects \
+  mysql:8
+
+docker run -d --name so-redis -p 6380:6379 redis:7-alpine
+```
+
+```bash
+SOLID_OBJECTS_DATABASE_URL=mysql2://solid_objects:solid_objects@127.0.0.1:3307/solid_objects_test \
+  bundle exec rake test
+
+SOLID_OBJECTS_REDIS_URL=redis://127.0.0.1:6380/15 \
+  bundle exec rake test TEST=test/integration/redis_wake_up_test.rb
+```
+
+Stop them with `docker rm -f so-mysql so-redis`.
+
+## Recreating a database between runs
+
+The test helper migrates unconditionally, so a second run against a database
+that already has the tables fails with a duplicate-table error rather than a
+test failure. Recreate first:
+
+```bash
+dropdb -h 127.0.0.1 solid_objects_test && createdb -h 127.0.0.1 -O solid_objects solid_objects_test
+
+docker exec so-mysql mysql -u root -psolid_objects \
+  -e "DROP DATABASE IF EXISTS solid_objects_test; CREATE DATABASE solid_objects_test;
+      GRANT ALL ON solid_objects_test.* TO 'solid_objects'@'%';"
+```
+
+## Rails and Ruby span
+
+`RAILS_VERSION` pins the Rails line the gemspec advertises:
+
+```bash
+RAILS_VERSION=8.0 bundle install
+RAILS_VERSION=8.0 bundle exec rake test
+```
+
+## Browser modules
+
+```bash
+npm install
+npm test                                  # jsdom, fast
+npx playwright install chromium
+npm run test:browser                      # real Chromium and a real Turbo build
+```
+
+The jsdom suite covers logic; the browser suite covers integration with Turbo.
+Both matter: every batching defect that reached production passed the jsdom
+suite alone.

--- a/lib/solid_objects/version.rb
+++ b/lib/solid_objects/version.rb
@@ -1,5 +1,5 @@
 # rbs_inline: enabled
 
 module SolidObjects
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
Sets 0.9.0 after merging #18, #19, #20, and #21.

## Why a minor rather than a patch

Three additions to the public surface: `WakeUpAdapters::Redis`, adapter `server_version` and `unsupported_server_reasons`, and a new `database_server` doctor check that can warn where the doctor previously said nothing.

## QA performed on main before bumping

| Dimension | Result |
| --- | --- |
| SQLite, full `rake` | 333 runs, 1187 assertions, 0 failures |
| PostgreSQL 17 | 333 runs, 0 failures |
| Rails 8.0 pin | 333 runs, 0 failures |
| jsdom suite | 26 pass |
| Real browser suite | 5 pass |
| Standard, RuboCop, RBS, Steep, Brakeman | clean |
| `gem build` | 0.9.0 |

MySQL was not run locally; CI covers it, along with the Redis job and the four-cell Ruby/Rails matrix.

## Merge conflicts resolved along the way

Each of the four PRs edited `docs/roadmap.md`, and two edited `CHANGELOG.md`, so every rebase conflicted. Resolutions combined both sides rather than choosing one:

- #19 needed #18's corrected milestone wording **and** its own renumbering
- #20 removed a different milestone than #19 had, so the list was renumbered sequentially rather than patched
- Every changelog conflict merged into a single `Unreleased` section; all entries were verified present afterwards

That renumbering churn is a consequence of a numbered milestone list. Worth considering unnumbered milestones later so parallel work stops colliding on line numbers.