### PR TITLE
docs: separate the security milestone, and test Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [ "3.3", "3.4" ]
+        ruby-version: [ "3.3", "3.4", "4.0" ]
         rails-version: [ "8.0", "8.1" ]
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add Ruby 4.0 to the compatibility matrix, which now covers Ruby 3.3, 3.4, and
+  4.0 against Rails 8.0 and 8.1.
+
 ## 0.9.0 - 2026-08-10
 
 - Add a browser test suite running the refresh modules against real Chromium and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,8 @@
   RuboCop policy, and a warning-free Brakeman scan
 - Compatibility CI across the supported span: Ruby 3.3 and 3.4 against Rails 8.0
   and 8.1, pinned through `RAILS_VERSION` so the advertised range is verified
-  rather than assumed
+  rather than assumed. Ruby 4.0 is not in the matrix, and the gemspec does not
+  advertise it
 - A JavaScript suite covering every browser module, run in CI with Node's test
   runner and jsdom, plus a browser suite running the same modules against real
   Chromium and a real Turbo build, with every GitHub Actions reference pinned to
@@ -86,8 +87,8 @@
 3. Add Turbo append intents and expand reconnect coverage in a full browser.
 4. Add distributed rate limits, global admission hooks, and cache-capacity
    eviction.
-5. Expand security scanning. Compatibility CI across supported Rails and Ruby
-   versions is implemented; Ruby 4.0 is not yet in the matrix.
+5. Expand security scanning beyond the Brakeman scan, such as dependency
+   auditing and secret scanning.
 6. Benchmark all workloads under documented hardware/database settings and
    publish adapter-specific adoption measurements. Throughput, synchronous
    latency, query counts, and the three reactive delivery paths are measured on

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,10 +44,9 @@
   gem's dependencies
 - Inline RBS generation/validation, Steep, Standard Ruby, Solid Queue's exact
   RuboCop policy, and a warning-free Brakeman scan
-- Compatibility CI across the supported span: Ruby 3.3 and 3.4 against Rails 8.0
-  and 8.1, pinned through `RAILS_VERSION` so the advertised range is verified
-  rather than assumed. Ruby 4.0 is not in the matrix, and the gemspec does not
-  advertise it
+- Compatibility CI across the supported span: Ruby 3.3, 3.4, and 4.0 against
+  Rails 8.0 and 8.1, pinned through `RAILS_VERSION` so the advertised range is
+  verified rather than assumed
 - A JavaScript suite covering every browser module, run in CI with Node's test
   runner and jsdom, plus a browser suite running the same modules against real
   Chromium and a real Turbo build, with every GitHub Actions reference pinned to


### PR DESCRIPTION
Two related changes to what the project claims about itself.

## The milestone wording

Milestone 5 read as "Expand security scanning. Compatibility CI across supported Rails and Ruby versions is implemented; Ruby 4.0 is not yet in the matrix."

Leading with a capability already recorded under "Implemented and tested" made a still-open milestone look like a completed item filed in the wrong section.

The milestone does belong where it is: compatibility CI shipped in #17, but **expanding security scanning has not**. Brakeman runs; there is no dependency auditing, secret scanning, or code scanning. So the milestone now states only what remains.

This is what the #15 rule was meant to catch, and it slipped through because I appended a caveat to a milestone instead of correcting the entry it belonged to.

## Ruby 4.0 in the matrix

The gemspec requires Ruby `>= 3.3`, so 4.0 was already inside the advertised range and simply untested. That is the gap the compatibility job exists to close.

Verified locally on Ruby 4.0.5 before adding it:

| | |
| --- | --- |
| Ruby 4.0.5 + Rails 8.1 | 333 runs, 0 failures |
| Ruby 4.0.5 + Rails 8.0 | 333 runs, 0 failures |

Development has run on 4.0.5 throughout this work, so this records something already true rather than making a new claim. The matrix goes from four cells to six.

The Ruby 4.0 caveat is removed from the compatibility entry, since it no longer applies.

```bash
bundle exec rake                          # 333 runs, 0 failures
RAILS_VERSION=8.0 bundle exec rake test   # 333 runs, 0 failures, on Ruby 4.0.5
```

No version bump: CI and documentation only.