### PR TITLE
fix: clear every actor-owned table in reset_actors!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- Delete every actor-owned row in `SolidObjects::TestHelper#reset_actors!`. It
+  deleted actor instances and processes and left the other seven tables to the
+  database cascade. That cascade is not enforced everywhere: SQLite has to be
+  asked for foreign keys, MySQL has to be on InnoDB, and a host application may
+  have stripped the constraints out of the copied migration. Where it does not
+  fire, messages, ready and claimed mailbox rows, reminders, effects,
+  broadcasts, and dead letters all survived into the next test with an
+  `instance_id` pointing at nothing, so a test reading any of them saw another
+  test's rows and failed depending on order. Reported as reminders leaking,
+  which is where it surfaces first because reminders outlive the message that
+  created them.
+
 ## 0.10.2 - 2026-08-10
 
 - Load the mailbox when the gem is required. `SolidObjects::Mailbox` was

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,7 +66,13 @@ Pass `roles: [:actors]` when a test intentionally wants to leave outboxes or
 reminders pending.
 
 `SolidObjects::TestHelper.reset_actors!` is also available for explicit suite
-boundaries.
+boundaries. It deletes every actor-owned row itself rather than deleting actor
+instances and letting the database cascade remove the rest: SQLite has to be
+asked for foreign keys, MySQL has to be on InnoDB, and a host application may
+have stripped the constraints out of the copied migration. Where the cascade
+does not fire, a row that survives a reset carries an `instance_id` pointing at
+nothing, and the next test that reads reminders or dead letters sees another
+test's data.
 
 ## Inline RBS
 

--- a/lib/solid_objects/test_helper.rb
+++ b/lib/solid_objects/test_helper.rb
@@ -12,11 +12,34 @@ module SolidObjects
         test_case.teardown { reset_actors! }
       end
 
+      # Deleting instances alone left every other actor-owned row to the
+      # database cascade. That cascade is not enforced everywhere: SQLite has
+      # to be asked for foreign keys, MySQL has to be on InnoDB, and a host
+      # application may have stripped the constraints out of the copied
+      # migration. Where it does not fire, rows survive into the next test with
+      # an instance_id pointing at nothing, and a test that reads them sees
+      # another test's data. Deleting each table costs nothing and does not
+      # depend on referential integrity.
       # @rbs () -> void
       def reset_actors!
         SolidObjects.reset_caller_process!
-        Instance.delete_all
+        actor_owned_models.each(&:delete_all)
         Process.delete_all
+      end
+
+      # Children first, so the order is safe whether or not the cascade fires.
+      # @rbs () -> Array[Class]
+      def actor_owned_models
+        [
+          DeadLetter,
+          ClaimedMessage,
+          ReadyMessage,
+          Broadcast,
+          Effect,
+          Reminder,
+          Message,
+          Instance
+        ]
       end
     end
 

--- a/sig/generated/lib/solid_objects/test_helper.rbs
+++ b/sig/generated/lib/solid_objects/test_helper.rbs
@@ -5,8 +5,20 @@ module SolidObjects
     # @rbs (Class) -> void
     def self.included: (Class) -> void
 
+    # Deleting instances alone left every other actor-owned row to the
+    # database cascade. That cascade is not enforced everywhere: SQLite has
+    # to be asked for foreign keys, MySQL has to be on InnoDB, and a host
+    # application may have stripped the constraints out of the copied
+    # migration. Where it does not fire, rows survive into the next test with
+    # an instance_id pointing at nothing, and a test that reads them sees
+    # another test's data. Deleting each table costs nothing and does not
+    # depend on referential integrity.
     # @rbs () -> void
     def self.reset_actors!: () -> void
+
+    # Children first, so the order is safe whether or not the cascade fires.
+    # @rbs () -> Array[Class]
+    def self.actor_owned_models: () -> Array[Class]
 
     # @rbs () -> void
     def reset_actors!: () -> void

--- a/test/integration/public_test_helper_test.rb
+++ b/test/integration/public_test_helper_test.rb
@@ -48,6 +48,37 @@ class PublicTestHelperTest < ActiveSupport::TestCase
     assert_empty SolidObjects::Process.all
   end
 
+  # The helper used to delete instances and let the database cascade remove
+  # everything else. Where the cascade does not fire, rows survive into the
+  # next test pointing at an instance that no longer exists, and a test that
+  # reads them sees another test's data.
+  test "reset actors clears actor-owned rows without the database cascade" do
+    skip unless database_family == :sqlite
+
+    instance = create_actor_owned_rows
+    without_foreign_keys do
+      SolidObjects::TestHelper.reset_actors!
+    end
+
+    remaining = SolidObjects::TestHelper.actor_owned_models.reject { |model| model.count.zero? }
+    assert_empty remaining.map(&:table_name),
+      "these tables survived a reset that could not rely on the cascade"
+    refute_nil instance
+  end
+
+  # A table added later is only covered if the helper is told about it, and the
+  # cascade would hide the omission on every database that enforces it.
+  test "every actor-owned table is in the reset list" do
+    owned = SolidObjects::Record.connection.tables
+      .grep(/\Asolid_objects_/)
+      .reject { |table| table == "solid_objects_test_domain_records" }
+      .sort
+    listed = SolidObjects::TestHelper.actor_owned_models.map(&:table_name)
+
+    assert_equal owned, (listed + [ SolidObjects::Process.table_name ]).sort,
+      "a Solid Objects table is missing from reset_actors!"
+  end
+
   test "drain actor messages processes queued work deterministically" do
     test_case = ActorTestCase.new("unused")
     message_reference = HelperActor.ref("async").async(:increment)
@@ -89,5 +120,91 @@ class PublicTestHelperTest < ActiveSupport::TestCase
     end
 
     assert_includes error.message, "unknown"
+  end
+
+  private
+
+  # One row in every actor-owned table, so an omission from the reset list
+  # shows up as a surviving table rather than as a passing test.
+  def create_actor_owned_rows
+    now = Time.current
+    instance = SolidObjects::Instance.create!(
+      actor_type: "reset-probe",
+      actor_id: "one",
+      state: {},
+      state_version: 1
+    )
+    message = SolidObjects::Message.create!(
+      instance:,
+      actor_type: instance.actor_type,
+      actor_id: instance.actor_id,
+      message_name: "noop",
+      message_kind: "async",
+      arguments: {},
+      sequence: 1,
+      max_attempts: 1,
+      request_id: SecureRandom.uuid,
+      enqueued_at: now,
+      available_at: now
+    )
+    SolidObjects::ReadyMessage.create!(message:, instance:, sequence: 1, available_at: now)
+    SolidObjects::ClaimedMessage.create!(
+      message:,
+      instance:,
+      activation_generation: 1,
+      claimed_at: now
+    )
+    SolidObjects::Reminder.create!(
+      instance:,
+      actor_type: instance.actor_type,
+      actor_id: instance.actor_id,
+      name: "probe",
+      message_name: "noop",
+      arguments: {},
+      next_run_at: now,
+      status: "scheduled"
+    )
+    SolidObjects::Effect.create!(
+      instance:,
+      message:,
+      effect_id: SecureRandom.uuid,
+      name: "probe",
+      arguments: {},
+      max_attempts: 1,
+      available_at: now
+    )
+    SolidObjects::Broadcast.create!(
+      instance:,
+      message:,
+      broadcast_id: SecureRandom.uuid,
+      observable_name: "probe",
+      value: {},
+      state_version: 1,
+      activation_generation: 1,
+      available_at: now
+    )
+    SolidObjects::DeadLetter.create!(
+      instance:,
+      message:,
+      actor_type: instance.actor_type,
+      actor_id: instance.actor_id,
+      message_name: "noop",
+      arguments: {},
+      attempts: 1,
+      exception_class: "RuntimeError",
+      exception_message: "probe",
+      backtrace: [],
+      first_failed_at: now,
+      last_failed_at: now
+    )
+    instance
+  end
+
+  def without_foreign_keys
+    connection = SolidObjects::Record.connection
+    connection.execute("PRAGMA foreign_keys = OFF")
+    yield
+  ensure
+    connection.execute("PRAGMA foreign_keys = ON")
   end
 end


### PR DESCRIPTION
Fixes the reported test-isolation gap. Confirmed, and it is wider than reminders.

## What the helper did

```ruby
def reset_actors!
  SolidObjects.reset_caller_process!
  Instance.delete_all
  Process.delete_all
end
```

Two tables deleted, seven left to the database cascade. Every actor-owned table has an `on_delete: :cascade` foreign key to `solid_objects_instances`, so on a database that enforces it the cascade removes the rest and the helper looks complete.

**It is only complete where referential integrity is enforced.** SQLite has to be asked for foreign keys, MySQL has to be on InnoDB, and a host application may have stripped the constraints out of the copied migration, which is standing policy in some shops. Where the cascade does not fire, rows survive a reset with an `instance_id` pointing at nothing, and the next test that reads them sees another test's data.

## Reproduced

With `PRAGMA foreign_keys = OFF`, matching a host application whose database does not enforce the cascade:

```
after reset: instances=0 reminders=1
orphan instance_id: 1
```

That is exactly the described state: a reminder whose `instance_id` points at nothing.

## It was not only reminders

Restoring the old two-line body with the new test in place shows what actually survived:

```
Expected ["solid_objects_dead_letters", "solid_objects_claimed_messages",
          "solid_objects_ready_messages", "solid_objects_broadcasts",
          "solid_objects_effects", "solid_objects_reminders",
          "solid_objects_messages"] to be empty.
```

Reminders are simply where it surfaces first, because they outlive the message that created them and a suite is likely to assert on them directly. Leftover dead letters or claimed mailbox rows would have been just as capable of failing a test by order.

## The fix

`reset_actors!` deletes each actor-owned table itself, children before parents so the order is correct whether or not the cascade fires. A test helper has no reason to depend on referential integrity.

## Tests

The existing test asserted only that instances and processes were empty, which is the same blind spot one level up: it could not have caught this. Two new tests:

- **clears actor-owned rows without the database cascade** populates all eight tables, resets with foreign keys switched off so the cascade cannot cover for an incomplete list, and asserts every table is empty. Verified to fail against the old body, naming all seven surviving tables.
- **every actor-owned table is in the reset list** compares the helper's list against the Solid Objects tables actually present in the schema, so a table added later cannot be omitted silently. On a database that enforces the cascade the omission would otherwise stay invisible.

## Validation

| Run | Result |
| --- | --- |
| `bundle exec rake` (SQLite) | 383 runs, 1282 assertions, 0 failures, 14 skips |
| Trilogy (docker MySQL 8) | 383 runs, 1242 assertions, 0 failures, 23 skips |
| PostgreSQL 17.6 | 383 runs, 1259 assertions, 0 failures, 15 skips |
| Standard, RuboCop, RBS, Steep, Brakeman | clean |

The foreign-key test skips on MySQL and PostgreSQL, which is the extra skip in those columns. Disabling enforcement there needs either a session-wide switch or superuser rights, and the fix is adapter independent, so the SQLite run carries it.

No version bump. The changelog entry sits under `Unreleased`, matching the separate release-prep workflow. Note that PR #30 is also open with an `Unreleased` entry, so whichever merges second will want a trivial changelog merge.