### PR TITLE
chore: prepare 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.10.3 - 2026-08-11
 
 - Delete every actor-owned row in `SolidObjects::TestHelper#reset_actors!`. It
   deleted actor instances and processes and left the other seven tables to the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_objects (0.10.2)
+    solid_objects (0.10.3)
       actioncable (>= 8.0)
       actionpack (>= 8.0)
       actionview (>= 8.0)
@@ -383,7 +383,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  solid_objects (0.10.2)
+  solid_objects (0.10.3)
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,8 @@
   result recovery
 - Bounded message/process pruning, actor-type opt-in instance expiration,
   graceful caller shutdown, committed state snapshots, and an opt-in Minitest
-  helper
+  helper that clears every actor-owned table itself rather than relying on the
+  database cascade, which a host application may not enforce
 - Supervisor role replacement: a role whose thread dies is restarted until
   shutdown is requested, and dead process records plus expired message and
   process history are pruned on their own intervals without an application

--- a/lib/solid_objects/version.rb
+++ b/lib/solid_objects/version.rb
@@ -1,5 +1,5 @@
 # rbs_inline: enabled
 
 module SolidObjects
-  VERSION = "0.10.2"
+  VERSION = "0.10.3"
 end


### PR DESCRIPTION
Bumps to 0.10.3 and records a QA pass over the whole gate.

## Why 0.10.3

Two fixes and a documentation gap since 0.10.2, all reported from production use, none of them API changes:

- reminder uniqueness was undocumented, and an actor arming one alarm per queued item silently kept only the last
- `solid_objects.reminder.replaced` makes that replacement visible
- `TestHelper#reset_actors!` left seven tables behind wherever the database cascade is not enforced

A patch bump is right: nothing added to the public API except one instrumentation event, and no behaviour changed for existing callers.

## QA pass

Everything below was run by hand on this branch.

| Check | Result |
| --- | --- |
| `bundle exec rake` (SQLite) | 390 runs, 1303 assertions, 0 failures, 14 skips |
| mysql2 (docker MySQL 8) | 390 runs, 1263 assertions, 0 failures, 23 skips |
| **Trilogy** (docker MySQL 8) | 390 runs, 1263 assertions, 0 failures, 23 skips |
| PostgreSQL 17.6 | 390 runs, 1280 assertions, 0 failures, 15 skips |
| Redis wake-up (docker, 6380) | 10 runs, 0 failures, **0 skips** |
| PostgreSQL wake-up | 10 runs, 0 failures, **0 skips** |
| `npm test` / `npm run test:browser` | 26 pass / 13 pass |
| Standard, RuboCop, RBS, Steep, Brakeman | clean |
| `gem build` + contents | 109 Ruby and JS files, no `test/`, no `node_modules` |
| Doctor against a real app | 6 checks, healthy, reports `schema matches the 0.10.3 runtime` |
| CLI denial path | prints the policy and the setting, exits 1 |
| `benchmark/query_count.rb` | 26 / 49 / 75, matching the documented figures |
| `ruby -c` on shipped examples | Syntax OK |

Both wake-up suites were run with their services configured rather than left to skip, since a skip and a pass look identical in the summary line. Both MySQL clients were run, since an adapter name, a connection collation, and an error code name all differ between them.

## Findings

**Nothing new.** The three previous release QA passes each turned up something; this one did not, which is what I would expect now that the CLI, benchmark, and adapter gaps found in 0.10.0 and 0.10.1 are closed and the load contract test guards the class of bug behind 0.10.2.

One documentation correction, from re-reading the roadmap against the code: the "opt-in Minitest helper" entry now records that the helper clears actor-owned tables itself rather than relying on a cascade a host application may not enforce. That is the behaviour shipped in #31, and the entry read as if the helper simply worked.

The query counts are worth calling out because they are deterministic rather than machine-dependent: 26 for a message turn, 49 for the caller of a synchronous call, 75 combined. Unchanged since they were re-measured for 0.10.0, so nothing in the last three releases has moved the per-call database cost.

Ready to tag once merged.