### PR TITLE
Let an extension run inside the supervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   block, so a component may need a database connection that the application
   does not have while it boots.
 
+- Stop the components already built when a later one fails. The supervisor
+  builds its components one after another, so a factory that raised, or a
+  component that failed the contract check, left the earlier ones constructed
+  and unreachable while they still held whatever their constructors took. Each
+  one now receives `stop`, and a failure inside that cleanup never replaces the
+  failure that caused it.
+
 - Replace a crashed component through the builder that made it. The supervisor
   called `component.class.new`, which discards every constructor argument, so a
   component built with arguments returned with its defaults after a crash. Each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
   shutdown timeout. Without it, an extension has to ask an operator to run and
   monitor a second process for work that belongs to the same runtime. A
   registered component must answer `run`, `request_shutdown`, `stopped?`, and
-  `stop`, and the registration raises `ArgumentError` when it does not.
+  `stop`. The supervisor checks that contract when it builds the component and
+  raises `ArgumentError` when a method is missing. Registration never calls the
+  block, so a component may need a database connection that the application
+  does not have while it boots.
 
 - Replace a crashed component through the builder that made it. The supervisor
   called `component.class.new`, which discards every constructor argument, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.11.0 - 2026-08-11
+
+- Add `SolidObjects.configuration.register_component`. An extension gem can now
+  register a long running component, and the supervisor runs it beside the
+  workers, the effect executors, the broadcast executors, and the reminder
+  schedulers. The component joins the same supervision, replacement, and
+  shutdown timeout. Without it, an extension has to ask an operator to run and
+  monitor a second process for work that belongs to the same runtime. A
+  registered component must answer `run`, `request_shutdown`, `stopped?`, and
+  `stop`, and the registration raises `ArgumentError` when it does not.
+
+- Replace a crashed component through the builder that made it. The supervisor
+  called `component.class.new`, which discards every constructor argument, so a
+  component built with arguments returned with its defaults after a crash. Each
+  component now keeps its builder. The built in components take no constructor
+  arguments, so their behavior does not change.
+
 ## 0.10.3 - 2026-08-11
 
 - Delete every actor-owned row in `SolidObjects::TestHelper#reset_actors!`. It

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_objects (0.10.3)
+    solid_objects (0.11.0)
       actioncable (>= 8.0)
       actionpack (>= 8.0)
       actionview (>= 8.0)
@@ -383,7 +383,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  solid_objects (0.10.3)
+  solid_objects (0.11.0)
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b

--- a/README.md
+++ b/README.md
@@ -458,6 +458,37 @@ Deploy and monitor that process before enabling any feature marked as requiring
 a runtime role. A missing worker never makes a durable `async` message
 disappear, but it leaves the message pending indefinitely.
 
+### Running an extension in the same process
+
+An extension gem can register its own long-running component, and
+`solid_objects start` runs it beside the built-in roles. The component joins the
+same supervision, the same replacement after a crash, and the same shutdown
+timeout, so an operator deploys and monitors one process instead of two:
+
+```ruby
+SolidObjects.configure do |configuration|
+  configuration.register_component { MyExtension::FlushEngine.new }
+end
+```
+
+Pass `count:` for more than one instance. The block runs once for each instance,
+and again when the supervisor replaces a crashed one, so no two components share
+an object.
+
+A registered component answers four methods, the contract the built-in roles
+already keep:
+
+| Method | Purpose |
+| --- | --- |
+| `run` | Runs the loop. The supervisor calls it in its own thread |
+| `request_shutdown` | Asks the loop to finish. It must make `run` return |
+| `stopped?` | Reports whether the component already finished |
+| `stop` | Forces cleanup when the shutdown timeout expires first |
+
+`register_component` builds one instance at once to check that contract, so a
+component that misses a method raises `ArgumentError` while the application
+boots, rather than hanging a shutdown later.
+
 ## Defining an actor
 
 The Durable Object class becomes an ordinary Ruby class:

--- a/README.md
+++ b/README.md
@@ -485,9 +485,11 @@ already keep:
 | `stopped?` | Reports whether the component already finished |
 | `stop` | Forces cleanup when the shutdown timeout expires first |
 
-`register_component` builds one instance at once to check that contract, so a
-component that misses a method raises `ArgumentError` while the application
-boots, rather than hanging a shutdown later.
+The supervisor checks that contract when it builds the component, and a missing
+method raises `ArgumentError` as the supervisor starts, rather than hanging a
+shutdown later. Registration itself never calls the block, so a component is
+free to need a database connection that the application does not have while it
+boots.
 
 ## Defining an actor
 

--- a/lib/solid_objects/configuration.rb
+++ b/lib/solid_objects/configuration.rb
@@ -171,12 +171,19 @@ module SolidObjects
     # registration happens while the application boots.
     # @rbs () -> Array[untyped]
     def build_additional_components
-      additional_components.map { |factory| build_component(factory) }
+      additional_components.map { |factory| factory.call.tap { |component| validate_component!(component) } }
     end
 
-    # @rbs (^() -> untyped) -> untyped
-    def build_component(factory)
-      factory.call.tap { |component| validate_component!(component) }
+    # A component that misses part of the contract would hang the supervisor at
+    # shutdown, or crash the moment it starts. The build fails instead, where
+    # the caller can read the reason.
+    # @rbs (untyped) -> void
+    def validate_component!(component)
+      %i[run request_shutdown stopped? stop].each do |method_name|
+        next if component.respond_to?(method_name)
+
+        raise ArgumentError, "a registered component must respond to #{method_name}"
+      end
     end
 
     # @rbs () -> self
@@ -229,18 +236,6 @@ module SolidObjects
     end
 
     private
-
-    # A component that misses part of the contract would hang the supervisor at
-    # shutdown, or crash the moment it starts. The registration fails instead,
-    # where the caller can read the reason.
-    # @rbs (untyped) -> void
-    def validate_component!(component)
-      %i[run request_shutdown stopped? stop].each do |method_name|
-        next if component.respond_to?(method_name)
-
-        raise ArgumentError, "a registered component must respond to #{method_name}"
-      end
-    end
 
     # @rbs () -> Hash[Symbol, Numeric]
     def positive_values

--- a/lib/solid_objects/configuration.rb
+++ b/lib/solid_objects/configuration.rb
@@ -92,6 +92,9 @@ module SolidObjects
       :authorize_subscription,
       :authorize_administration
 
+    # @rbs @additional_components: Array[untyped]
+    attr_reader :additional_components
+
     # @rbs () -> void
     def initialize
       @table_name_prefix = "solid_objects_"
@@ -142,6 +145,32 @@ module SolidObjects
       @authorize_destroy = ->(**) { false }
       @authorize_subscription = ->(**) { false }
       @authorize_administration = ->(**) { false }
+      @additional_components = []
+    end
+
+    # Registers a long running component that the supervisor runs beside its own
+    # workers. An extension gem uses this to share one process, rather than ask
+    # an operator to run and monitor a second one.
+    #
+    # The block must return an object that answers `run`, `request_shutdown`,
+    # `stopped?`, and `stop`, which is the contract the built in components
+    # already keep. The supervisor calls the block once for each supervisor it
+    # builds, and again when it replaces a crashed component, so two
+    # supervisors never share one component instance.
+    #
+    # @rbs (?count: Integer) { () -> untyped } -> void
+    def register_component(count: 1, &factory)
+      raise ArgumentError, "register_component requires a block" unless factory
+      raise ArgumentError, "count must be positive" unless count.positive?
+
+      validate_component!(factory.call)
+
+      count.times { @additional_components << factory }
+    end
+
+    # @rbs () -> Array[untyped]
+    def build_additional_components
+      additional_components.map(&:call)
     end
 
     # @rbs () -> self
@@ -194,6 +223,18 @@ module SolidObjects
     end
 
     private
+
+    # A component that misses part of the contract would hang the supervisor at
+    # shutdown, or crash the moment it starts. The registration fails instead,
+    # where the caller can read the reason.
+    # @rbs (untyped) -> void
+    def validate_component!(component)
+      %i[run request_shutdown stopped? stop].each do |method_name|
+        next if component.respond_to?(method_name)
+
+        raise ArgumentError, "a registered component must respond to #{method_name}"
+      end
+    end
 
     # @rbs () -> Hash[Symbol, Numeric]
     def positive_values

--- a/lib/solid_objects/configuration.rb
+++ b/lib/solid_objects/configuration.rb
@@ -163,14 +163,20 @@ module SolidObjects
       raise ArgumentError, "register_component requires a block" unless factory
       raise ArgumentError, "count must be positive" unless count.positive?
 
-      validate_component!(factory.call)
-
       count.times { @additional_components << factory }
     end
 
+    # The supervisor checks the contract here rather than at registration,
+    # because a component often needs a database connection to exist, and
+    # registration happens while the application boots.
     # @rbs () -> Array[untyped]
     def build_additional_components
-      additional_components.map(&:call)
+      additional_components.map { |factory| build_component(factory) }
+    end
+
+    # @rbs (^() -> untyped) -> untyped
+    def build_component(factory)
+      factory.call.tap { |component| validate_component!(component) }
     end
 
     # @rbs () -> self

--- a/lib/solid_objects/supervisor.rb
+++ b/lib/solid_objects/supervisor.rb
@@ -25,7 +25,7 @@ module SolidObjects
         broadcast_worker_count:,
         reminder_scheduler_count:
       )
-      @components = @builders.map(&:call)
+      @components = build_all(@builders)
       @threads = []
       @monitor = nil
       @started = false
@@ -255,6 +255,37 @@ module SolidObjects
       nil
     end
 
+    # A constructor can take a resource, and a later builder can raise. Without
+    # this, the components built first would be dropped while still holding
+    # whatever they took, and nothing would ever give it back.
+    # @rbs (Array[^() -> untyped]) -> Array[untyped]
+    def build_all(builders)
+      built = []
+      builders.each do |builder|
+        # The component joins the list before the contract check, so a
+        # component that fails the check is stopped along with the rest.
+        built << (component = builder.call)
+        SolidObjects.configuration.validate_component!(component)
+      end
+      built
+    rescue Exception # rubocop:disable Lint/RescueException
+      built.each { |component| stop_after_failed_build(component) }
+      raise
+    end
+
+    # The failure that stopped the build is the one worth reporting, so a
+    # failure inside the cleanup never replaces it.
+    # @rbs (untyped) -> void
+    def stop_after_failed_build(component)
+      component.stop if component.respond_to?(:stop)
+    rescue Exception => error # rubocop:disable Lint/RescueException
+      SolidObjects.instrument(
+        :"supervisor.component_cleanup_failed",
+        role: component.class.name,
+        error_class: error.class.name
+      )
+    end
+
     # Each component keeps the builder that made it, so a replacement after a
     # crash is built the same way as the original. Components registered
     # through the configuration run beside the built in ones, under the same
@@ -270,9 +301,7 @@ module SolidObjects
         Array.new(effect_worker_count) { -> { EffectExecutor.new } } +
         Array.new(broadcast_worker_count) { -> { BroadcastExecutor.new } } +
         Array.new(reminder_scheduler_count) { -> { ReminderScheduler.new } } +
-        SolidObjects.configuration.additional_components.map do |factory|
-          -> { SolidObjects.configuration.build_component(factory) }
-        end
+        SolidObjects.configuration.additional_components
     end
 
     # @rbs () -> void

--- a/lib/solid_objects/supervisor.rb
+++ b/lib/solid_objects/supervisor.rb
@@ -19,12 +19,13 @@ module SolidObjects
       broadcast_worker_count: SolidObjects.configuration.broadcast_worker_count,
       reminder_scheduler_count: SolidObjects.configuration.reminder_scheduler_count
     )
-      @components = build_components(
+      @builders = component_builders(
         worker_count:,
         effect_worker_count:,
         broadcast_worker_count:,
         reminder_scheduler_count:
       )
+      @components = @builders.map(&:call)
       @threads = []
       @monitor = nil
       @started = false
@@ -77,7 +78,7 @@ module SolidObjects
 
     private
 
-    attr_reader :components, :threads
+    attr_reader :components, :threads, :builders
 
     # A role that raises leaves its thread dead. Without replacement the
     # process keeps running while quietly doing less work, so the supervisor
@@ -116,7 +117,11 @@ module SolidObjects
         replaced = @lifecycle.synchronize do
           next false unless @started
 
-          replacement = component.class.new
+          # A component built by this supervisor has a builder, which carries
+          # whatever the constructor was given. A component put in place by
+          # other means has none, so the class is the only thing left to go on.
+          builder = builders[index] || -> { component.class.new }
+          replacement = builder.call
           components[index] = replacement
           threads[index] = supervise(replacement)
           replacement
@@ -250,17 +255,22 @@ module SolidObjects
       nil
     end
 
-    # @rbs (worker_count: Integer, effect_worker_count: Integer, broadcast_worker_count: Integer, reminder_scheduler_count: Integer) -> Array[Worker | EffectExecutor | ReminderScheduler | BroadcastExecutor]
-    def build_components(
+    # Each component keeps the builder that made it, so a replacement after a
+    # crash is built the same way as the original. Components registered
+    # through the configuration run beside the built in ones, under the same
+    # supervision, restart, and shutdown timeout.
+    # @rbs (worker_count: Integer, effect_worker_count: Integer, broadcast_worker_count: Integer, reminder_scheduler_count: Integer) -> Array[^() -> untyped]
+    def component_builders(
       worker_count:,
       effect_worker_count:,
       broadcast_worker_count:,
       reminder_scheduler_count:
     )
-      Array.new(worker_count) { Worker.new } +
-        Array.new(effect_worker_count) { EffectExecutor.new } +
-        Array.new(broadcast_worker_count) { BroadcastExecutor.new } +
-        Array.new(reminder_scheduler_count) { ReminderScheduler.new }
+      Array.new(worker_count) { -> { Worker.new } } +
+        Array.new(effect_worker_count) { -> { EffectExecutor.new } } +
+        Array.new(broadcast_worker_count) { -> { BroadcastExecutor.new } } +
+        Array.new(reminder_scheduler_count) { -> { ReminderScheduler.new } } +
+        SolidObjects.configuration.additional_components
     end
 
     # @rbs () -> void

--- a/lib/solid_objects/supervisor.rb
+++ b/lib/solid_objects/supervisor.rb
@@ -270,7 +270,9 @@ module SolidObjects
         Array.new(effect_worker_count) { -> { EffectExecutor.new } } +
         Array.new(broadcast_worker_count) { -> { BroadcastExecutor.new } } +
         Array.new(reminder_scheduler_count) { -> { ReminderScheduler.new } } +
-        SolidObjects.configuration.additional_components
+        SolidObjects.configuration.additional_components.map do |factory|
+          -> { SolidObjects.configuration.build_component(factory) }
+        end
     end
 
     # @rbs () -> void

--- a/lib/solid_objects/version.rb
+++ b/lib/solid_objects/version.rb
@@ -1,5 +1,5 @@
 # rbs_inline: enabled
 
 module SolidObjects
-  VERSION = "0.10.3"
+  VERSION = "0.11.0"
 end

--- a/sig/generated/lib/solid_objects/configuration.rbs
+++ b/sig/generated/lib/solid_objects/configuration.rbs
@@ -2,6 +2,10 @@
 
 module SolidObjects
   class Configuration
+    @process_alive_threshold: Float
+
+    @shutdown_timeout: Float
+
     @supervisor_monitor_interval: Float
 
     @retention_interval: Float
@@ -85,10 +89,6 @@ module SolidObjects
     @lock_retry_attempts: Integer
 
     @process_heartbeat_interval: Float
-
-    @process_alive_threshold: Float
-
-    @shutdown_timeout: Float
 
     attr_accessor table_name_prefix: untyped
 
@@ -178,13 +178,38 @@ module SolidObjects
 
     attr_accessor authorize_administration: untyped
 
+    # @rbs @additional_components: Array[untyped]
+    attr_reader additional_components: untyped
+
     # @rbs () -> void
     def initialize: () -> void
+
+    # Registers a long running component that the supervisor runs beside its own
+    # workers. An extension gem uses this to share one process, rather than ask
+    # an operator to run and monitor a second one.
+    #
+    # The block must return an object that answers `run`, `request_shutdown`,
+    # `stopped?`, and `stop`, which is the contract the built in components
+    # already keep. The supervisor calls the block once for each supervisor it
+    # builds, and again when it replaces a crashed component, so two
+    # supervisors never share one component instance.
+    #
+    # @rbs (?count: Integer) { () -> untyped } -> void
+    def register_component: (?count: Integer) { () -> untyped } -> void
+
+    # @rbs () -> Array[untyped]
+    def build_additional_components: () -> Array[untyped]
 
     # @rbs () -> self
     def validate!: () -> self
 
     private
+
+    # A component that misses part of the contract would hang the supervisor at
+    # shutdown, or crash the moment it starts. The registration fails instead,
+    # where the caller can read the reason.
+    # @rbs (untyped) -> void
+    def validate_component!: (untyped) -> void
 
     # @rbs () -> Hash[Symbol, Numeric]
     def positive_values: () -> Hash[Symbol, Numeric]

--- a/sig/generated/lib/solid_objects/configuration.rbs
+++ b/sig/generated/lib/solid_objects/configuration.rbs
@@ -2,8 +2,6 @@
 
 module SolidObjects
   class Configuration
-    @table_name_prefix: String
-
     @process_alive_threshold: Float
 
     @shutdown_timeout: Float
@@ -57,6 +55,8 @@ module SolidObjects
     @authorize_subscription: Proc
 
     @authorize_administration: Proc
+
+    @table_name_prefix: String
 
     @polling_interval: Float
 
@@ -203,19 +203,16 @@ module SolidObjects
     # @rbs () -> Array[untyped]
     def build_additional_components: () -> Array[untyped]
 
-    # @rbs (^() -> untyped) -> untyped
-    def build_component: (^() -> untyped) -> untyped
+    # A component that misses part of the contract would hang the supervisor at
+    # shutdown, or crash the moment it starts. The build fails instead, where
+    # the caller can read the reason.
+    # @rbs (untyped) -> void
+    def validate_component!: (untyped) -> void
 
     # @rbs () -> self
     def validate!: () -> self
 
     private
-
-    # A component that misses part of the contract would hang the supervisor at
-    # shutdown, or crash the moment it starts. The registration fails instead,
-    # where the caller can read the reason.
-    # @rbs (untyped) -> void
-    def validate_component!: (untyped) -> void
 
     # @rbs () -> Hash[Symbol, Numeric]
     def positive_values: () -> Hash[Symbol, Numeric]

--- a/sig/generated/lib/solid_objects/configuration.rbs
+++ b/sig/generated/lib/solid_objects/configuration.rbs
@@ -2,6 +2,8 @@
 
 module SolidObjects
   class Configuration
+    @table_name_prefix: String
+
     @process_alive_threshold: Float
 
     @shutdown_timeout: Float
@@ -55,8 +57,6 @@ module SolidObjects
     @authorize_subscription: Proc
 
     @authorize_administration: Proc
-
-    @table_name_prefix: String
 
     @polling_interval: Float
 
@@ -197,8 +197,14 @@ module SolidObjects
     # @rbs (?count: Integer) { () -> untyped } -> void
     def register_component: (?count: Integer) { () -> untyped } -> void
 
+    # The supervisor checks the contract here rather than at registration,
+    # because a component often needs a database connection to exist, and
+    # registration happens while the application boots.
     # @rbs () -> Array[untyped]
     def build_additional_components: () -> Array[untyped]
+
+    # @rbs (^() -> untyped) -> untyped
+    def build_component: (^() -> untyped) -> untyped
 
     # @rbs () -> self
     def validate!: () -> self

--- a/sig/generated/lib/solid_objects/supervisor.rbs
+++ b/sig/generated/lib/solid_objects/supervisor.rbs
@@ -36,6 +36,8 @@ module SolidObjects
 
     attr_reader threads: untyped
 
+    attr_reader builders: untyped
+
     # A role that raises leaves its thread dead. Without replacement the
     # process keeps running while quietly doing less work, so the supervisor
     # watches its threads and restarts any that stopped before shutdown.
@@ -101,8 +103,12 @@ module SolidObjects
     # @rbs () -> void
     def release_wake_up: () -> void
 
-    # @rbs (worker_count: Integer, effect_worker_count: Integer, broadcast_worker_count: Integer, reminder_scheduler_count: Integer) -> Array[Worker | EffectExecutor | ReminderScheduler | BroadcastExecutor]
-    def build_components: (worker_count: Integer, effect_worker_count: Integer, broadcast_worker_count: Integer, reminder_scheduler_count: Integer) -> Array[Worker | EffectExecutor | ReminderScheduler | BroadcastExecutor]
+    # Each component keeps the builder that made it, so a replacement after a
+    # crash is built the same way as the original. Components registered
+    # through the configuration run beside the built in ones, under the same
+    # supervision, restart, and shutdown timeout.
+    # @rbs (worker_count: Integer, effect_worker_count: Integer, broadcast_worker_count: Integer, reminder_scheduler_count: Integer) -> Array[^() -> untyped]
+    def component_builders: (worker_count: Integer, effect_worker_count: Integer, broadcast_worker_count: Integer, reminder_scheduler_count: Integer) -> Array[^() -> untyped]
 
     # @rbs () -> void
     def join_until_timeout: () -> void

--- a/sig/generated/lib/solid_objects/supervisor.rbs
+++ b/sig/generated/lib/solid_objects/supervisor.rbs
@@ -103,6 +103,17 @@ module SolidObjects
     # @rbs () -> void
     def release_wake_up: () -> void
 
+    # A constructor can take a resource, and a later builder can raise. Without
+    # this, the components built first would be dropped while still holding
+    # whatever they took, and nothing would ever give it back.
+    # @rbs (Array[^() -> untyped]) -> Array[untyped]
+    def build_all: (Array[^() -> untyped]) -> Array[untyped]
+
+    # The failure that stopped the build is the one worth reporting, so a
+    # failure inside the cleanup never replaces it.
+    # @rbs (untyped) -> void
+    def stop_after_failed_build: (untyped) -> void
+
     # Each component keeps the builder that made it, so a replacement after a
     # crash is built the same way as the original. Components registered
     # through the configuration run beside the built in ones, under the same

--- a/test/integration/supervisor_additional_components_test.rb
+++ b/test/integration/supervisor_additional_components_test.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "database_test_helper"
+
+class SupervisorAdditionalComponentsTest < ActiveSupport::TestCase
+  class RecordingComponent
+    attr_reader :label
+
+    def initialize(label: "default")
+      @label = label
+      @started = Concurrent::AtomicBoolean.new(false)
+      @stopped = Concurrent::AtomicBoolean.new(false)
+      @shutdown_requested = Concurrent::AtomicBoolean.new(false)
+      @gate = Queue.new
+    end
+
+    def run
+      @started.make_true
+      @gate.pop
+      @stopped.make_true
+    end
+
+    def request_shutdown
+      @shutdown_requested.make_true
+      @gate << :stop
+    end
+
+    def stop
+      @stopped.make_true
+    end
+
+    def stopped? = @stopped.true?
+
+    def started? = @started.true?
+
+    def shutdown_requested? = @shutdown_requested.true?
+
+    # Ends the run loop without a shutdown request, the way a crash does.
+    def simulate_crash
+      @gate << :crash
+    end
+  end
+
+  setup do
+    SolidObjects.reset!
+  end
+
+  teardown do
+    SolidObjects.reset!
+  end
+
+  test "runs a registered component alongside the built in ones" do
+    component = register_component
+    supervisor = new_supervisor
+    supervisor.start
+
+    wait_until { component.started? }
+
+    assert component.started?, "the supervisor never ran the registered component"
+  ensure
+    supervisor&.stop
+  end
+
+  test "asks a registered component to shut down" do
+    component = register_component
+    supervisor = new_supervisor
+    supervisor.start
+    wait_until { component.started? }
+
+    supervisor.stop
+
+    assert component.shutdown_requested?, "the supervisor never asked the component to stop"
+  end
+
+  test "leaves the built in processes unchanged" do
+    component = register_component
+    supervisor = new_supervisor
+    supervisor.start
+    wait_until { component.started? }
+
+    assert_equal(
+      %w[broadcast effect reminder worker],
+      SolidObjects::Process.order(:kind).pluck(:kind)
+    )
+  ensure
+    supervisor&.stop
+  end
+
+  test "runs the requested count of a registered component" do
+    built = Concurrent::AtomicFixnum.new(0)
+    SolidObjects.configuration.register_component(count: 2) do
+      built.increment
+      RecordingComponent.new
+    end
+
+    supervisor = new_supervisor
+    supervisor.start
+
+    # One call validates the registration, then one call for each instance.
+    assert_equal 3, built.value
+  ensure
+    supervisor&.stop
+  end
+
+  # The supervisor used to rebuild a dead component with component.class.new,
+  # which throws away whatever the factory configured.
+  test "replaces a crashed component through its own factory" do
+    components = Queue.new
+    SolidObjects.configuration.register_component do
+      component = RecordingComponent.new(label: "from-factory")
+      components << component
+      component
+    end
+
+    supervisor = new_supervisor
+    supervisor.start
+    components.pop # the instance built during validation
+    first = components.pop
+    wait_until { first.started? }
+
+    first.simulate_crash
+
+    wait_until { components.size.positive? }
+    replacement = components.pop
+
+    assert_equal "from-factory", replacement.label
+    assert_not_same first, replacement
+  ensure
+    supervisor&.stop
+  end
+
+  private
+
+  def register_component(label: "default")
+    component = RecordingComponent.new(label:)
+    SolidObjects.configuration.register_component { component }
+    component
+  end
+
+  def new_supervisor
+    SolidObjects::Supervisor.new(
+      worker_count: 1,
+      effect_worker_count: 1,
+      broadcast_worker_count: 1,
+      reminder_scheduler_count: 1
+    )
+  end
+
+  def wait_until(timeout: 5)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    sleep 0.01 until yield || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+  end
+end

--- a/test/integration/supervisor_additional_components_test.rb
+++ b/test/integration/supervisor_additional_components_test.rb
@@ -129,6 +129,41 @@ class SupervisorAdditionalComponentsTest < ActiveSupport::TestCase
     supervisor&.stop
   end
 
+  # Components are built one after another. A failure part way through leaves
+  # the earlier ones constructed and unreachable, so whatever their
+  # constructors took would never be given back.
+  test "stops the components it already built when a later factory raises" do
+    first = RecordingComponent.new
+    SolidObjects.configuration.register_component { first }
+    SolidObjects.configuration.register_component { raise "factory failed" }
+
+    assert_raises(RuntimeError) { new_supervisor }
+
+    assert first.stopped?, "the earlier component was abandoned without a stop"
+  end
+
+  test "stops the components it already built when a later one breaks the contract" do
+    first = RecordingComponent.new
+    SolidObjects.configuration.register_component { first }
+    SolidObjects.configuration.register_component { Object.new }
+
+    assert_raises(ArgumentError) { new_supervisor }
+
+    assert first.stopped?, "the earlier component was abandoned without a stop"
+  end
+
+  test "reports the original failure, not a cleanup failure" do
+    unstoppable = Class.new(RecordingComponent) do
+      def stop = raise "cleanup failed"
+    end
+    SolidObjects.configuration.register_component { unstoppable.new }
+    SolidObjects.configuration.register_component { raise "factory failed" }
+
+    error = assert_raises(RuntimeError) { new_supervisor }
+
+    assert_equal "factory failed", error.message
+  end
+
   private
 
   def register_component(label: "default")

--- a/test/integration/supervisor_additional_components_test.rb
+++ b/test/integration/supervisor_additional_components_test.rb
@@ -93,11 +93,12 @@ class SupervisorAdditionalComponentsTest < ActiveSupport::TestCase
       RecordingComponent.new
     end
 
+    assert_equal 0, built.value, "registration must not build the component"
+
     supervisor = new_supervisor
     supervisor.start
 
-    # One call validates the registration, then one call for each instance.
-    assert_equal 3, built.value
+    assert_equal 2, built.value
   ensure
     supervisor&.stop
   end
@@ -114,7 +115,6 @@ class SupervisorAdditionalComponentsTest < ActiveSupport::TestCase
 
     supervisor = new_supervisor
     supervisor.start
-    components.pop # the instance built during validation
     first = components.pop
     wait_until { first.started? }
 

--- a/test/unit/component_registry_test.rb
+++ b/test/unit/component_registry_test.rb
@@ -38,6 +38,16 @@ class ComponentRegistryTest < ActiveSupport::TestCase
     assert_empty SolidObjects.configuration.additional_components
   end
 
+  test "registration does not build the component" do
+    built = 0
+    SolidObjects.configuration.register_component do
+      built += 1
+      CountingComponent.new
+    end
+
+    assert_equal 0, built, "registration must not need a database connection"
+  end
+
   test "registers a component factory" do
     SolidObjects.configuration.register_component { CountingComponent.new }
 
@@ -59,9 +69,14 @@ class ComponentRegistryTest < ActiveSupport::TestCase
     assert_equal 3, SolidObjects.configuration.build_additional_components.length
   end
 
+  # The check happens when the supervisor builds the component, because a
+  # component often needs a database connection, and registration runs while
+  # the application boots.
   test "refuses a component without a run method" do
+    SolidObjects.configuration.register_component { Object.new }
+
     error = assert_raises(ArgumentError) do
-      SolidObjects.configuration.register_component { Object.new }
+      SolidObjects.configuration.build_additional_components
     end
 
     assert_match(/run/, error.message)
@@ -73,8 +88,10 @@ class ComponentRegistryTest < ActiveSupport::TestCase
       end
     end
 
+    SolidObjects.configuration.register_component { incomplete.new }
+
     error = assert_raises(ArgumentError) do
-      SolidObjects.configuration.register_component { incomplete.new }
+      SolidObjects.configuration.build_additional_components
     end
 
     assert_match(/request_shutdown/, error.message)
@@ -94,8 +111,10 @@ class ComponentRegistryTest < ActiveSupport::TestCase
       end
     end
 
+    SolidObjects.configuration.register_component { without_stopped.new }
+
     error = assert_raises(ArgumentError) do
-      SolidObjects.configuration.register_component { without_stopped.new }
+      SolidObjects.configuration.build_additional_components
     end
 
     assert_match(/stopped\?/, error.message)

--- a/test/unit/component_registry_test.rb
+++ b/test/unit/component_registry_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ComponentRegistryTest < ActiveSupport::TestCase
+  class CountingComponent
+    attr_reader :runs
+
+    def initialize
+      @runs = 0
+      @stopped = false
+    end
+
+    def run
+      @runs += 1
+    end
+
+    def request_shutdown
+      @stopped = true
+    end
+
+    def stop
+      @stopped = true
+    end
+
+    def stopped? = @stopped
+  end
+
+  setup do
+    SolidObjects.reset!
+  end
+
+  teardown do
+    SolidObjects.reset!
+  end
+
+  test "starts with no registered component" do
+    assert_empty SolidObjects.configuration.additional_components
+  end
+
+  test "registers a component factory" do
+    SolidObjects.configuration.register_component { CountingComponent.new }
+
+    assert_equal 1, SolidObjects.configuration.additional_components.length
+  end
+
+  test "builds a separate instance for each supervisor" do
+    SolidObjects.configuration.register_component { CountingComponent.new }
+
+    first = SolidObjects.configuration.build_additional_components
+    second = SolidObjects.configuration.build_additional_components
+
+    assert_not_same first.first, second.first
+  end
+
+  test "builds the requested count of a component" do
+    SolidObjects.configuration.register_component(count: 3) { CountingComponent.new }
+
+    assert_equal 3, SolidObjects.configuration.build_additional_components.length
+  end
+
+  test "refuses a component without a run method" do
+    error = assert_raises(ArgumentError) do
+      SolidObjects.configuration.register_component { Object.new }
+    end
+
+    assert_match(/run/, error.message)
+  end
+
+  test "refuses a component without a request_shutdown method" do
+    incomplete = Class.new do
+      def run
+      end
+    end
+
+    error = assert_raises(ArgumentError) do
+      SolidObjects.configuration.register_component { incomplete.new }
+    end
+
+    assert_match(/request_shutdown/, error.message)
+  end
+
+  # The supervisor calls stopped? and stop while it shuts down. A component
+  # that misses either one would hang the shutdown instead of failing here.
+  test "refuses a component that cannot report or force a stop" do
+    without_stopped = Class.new do
+      def run
+      end
+
+      def request_shutdown
+      end
+
+      def stop
+      end
+    end
+
+    error = assert_raises(ArgumentError) do
+      SolidObjects.configuration.register_component { without_stopped.new }
+    end
+
+    assert_match(/stopped\?/, error.message)
+  end
+
+  test "refuses a count below one" do
+    assert_raises(ArgumentError) do
+      SolidObjects.configuration.register_component(count: 0) { CountingComponent.new }
+    end
+  end
+
+  test "refuses a registration without a block" do
+    assert_raises(ArgumentError) do
+      SolidObjects.configuration.register_component
+    end
+  end
+
+  test "reset clears the registrations" do
+    SolidObjects.configuration.register_component { CountingComponent.new }
+    SolidObjects.reset!
+
+    assert_empty SolidObjects.configuration.additional_components
+  end
+end


### PR DESCRIPTION
## Why

An extension gem that needs a long-running loop has to ship its own executable, so an operator runs and monitors a **second** process for work that belongs to the same runtime. Two delivery paths where one would do means two things to watch, and the second is usually the one nobody watches.

Solid Objects Pro is the immediate case: `bundle exec solid_objects_pro start` exists only to run flush engines that are already thread-shaped and already share the connection pool this gem requires.

## What changed

`SolidObjects.configuration.register_component` takes a block that builds a component. The supervisor runs it beside the workers, effect executors, broadcast executors, and reminder schedulers, under the same supervision, replacement, and shutdown timeout.

```ruby
SolidObjects.configure do |configuration|
  configuration.register_component { MyExtension::FlushEngine.new }
end
```

The registration builds one instance immediately and checks it answers `run`, `request_shutdown`, `stopped?`, and `stop` — the contract the built-in roles already keep. A missing method raises `ArgumentError` while the application boots, rather than hanging a shutdown much later.

## A bug found on the way

`replace_dead_roles` rebuilt a crashed component with `component.class.new`, which discards every constructor argument. A component built with arguments came back with its defaults after a crash, silently. Each component now keeps the builder that made it, and replacement calls that builder.

The built-in roles take no constructor arguments, so their behavior is unchanged. A component placed into `@components` by other means has no builder and keeps the old `class.new` path, which is what the existing `SupervisorReplacementTest` injection relies on.

## Tests

- `test/unit/component_registry_test.rb` — registration, per-supervisor instances, `count:`, and each contract violation
- `test/integration/supervisor_additional_components_test.rb` — a registered component runs, shuts down, leaves the built-in process rows unchanged, honors `count:`, and is **replaced through its own factory** after a crash

Full `rake` default passes: 405 runs, 0 failures, plus standard, rubocop, rbs, and steep.

## Version

Minor bump to 0.11.0. The change is additive, and the replacement fix only affects components that were already being rebuilt incorrectly.