### PR TITLE
Secure realtime projections in 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.12.1 - 2026-08-13
+
+- Add invalidation-only observables with `broadcast: :invalidation`. They still
+  detect changes and refresh reactive components, but persist `{}` and send no
+  scalar value over Action Cable. Document that ordinary observable values are
+  shared with every authorized actor subscriber and that subscriber-specific
+  state belongs in a payload projection.
+- **Breaking:** include the originally staged `arguments:` in effect success
+  and failure callbacks so actors can correlate concurrent effects.
+- Accept identifier-style rejection codes, including camelCase and symbols,
+  and fail malformed codes once with non-retryable
+  `SolidObjects::InvalidRejectionCode` diagnostics.
+- Add `run_due_reminders(now:)` to `SolidObjects::TestHelper` for deterministic
+  reminder tests without sleeping or mutating runtime rows.
+
 ## 0.12.0 - 2026-08-13
 
 - Replace positional actor dispatch with fluent operation selection. Direct

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_objects (0.12.0)
+    solid_objects (0.12.1)
       actioncable (>= 8.0)
       actionpack (>= 8.0)
       actionview (>= 8.0)
@@ -383,7 +383,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  solid_objects (0.12.0)
+  solid_objects (0.12.1)
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b

--- a/README.md
+++ b/README.md
@@ -205,6 +205,21 @@ dependencies changes:
 <% end %>
 ```
 
+An observable's value is shared with every authorized subscriber by default
+and is stored in `solid_objects_broadcasts`. Use an invalidation-only observable
+for component dependencies whose value is private or subscriber-specific:
+
+```ruby
+observable :player_one, broadcast: :invalidation do
+  player_in_seat(1)
+end
+```
+
+Its value is still available to the authorized component renderer, but the
+durable row and Action Cable frame carry only invalidation metadata. It cannot
+be rendered as a scalar `<span>`. Put per-viewer state in `broadcast_payload`,
+which computes a fresh projection for each connection.
+
 Component names can repeat when each instance has a stable key. Signed
 JSON-compatible locals let one conventional partial render the matching
 projection:
@@ -736,8 +751,8 @@ JSON-compatible details. The rejected message remains durable for audit, actor
 state is rolled back, and no later mailbox turn is blocked.
 
 `Rejected#code` is a `String`, even when `reject` receives a symbol. Codes must
-match `\A[a-z][a-z0-9_]*\z`; invalid codes raise `ArgumentError` when the
-handler calls `reject`.
+match `\A[A-Za-z_][A-Za-z0-9_]*\z`. Invalid codes raise
+`SolidObjects::InvalidRejectionCode` and fail the turn without retrying.
 
 ### Redelivery
 
@@ -819,11 +834,11 @@ def checkout(payment_id:, amount_cents:)
   )
 end
 
-def payment_succeeded(effect_id:, result:)
+def payment_succeeded(effect_id:, arguments:, result:)
   self.checkout_status = "paid"
 end
 
-def payment_failed(effect_id:, error:)
+def payment_failed(effect_id:, arguments:, error:)
   self.checkout_status = "failed"
 end
 ```
@@ -842,6 +857,10 @@ end
 
 The provider call can repeat if a process dies after external success but
 before recording completion. The stable effect ID is the idempotency key.
+Success callbacks receive `effect_id:`, the originally staged `arguments:`,
+and `result:`. Failure callbacks receive `effect_id:`, `arguments:`, and
+`error:`, so an actor can correlate concurrent effects without storing a
+separate callback ledger.
 
 ## Reminders
 

--- a/app/models/solid_objects/broadcast.rb
+++ b/app/models/solid_objects/broadcast.rb
@@ -6,5 +6,13 @@ module SolidObjects
 
     belongs_to :message, class_name: "SolidObjects::Message"
     belongs_to :instance, class_name: "SolidObjects::Instance"
+
+    # @rbs () -> bool
+    def broadcasts_value?
+      return false if observable_name == PayloadBroadcast::REVISION_OBSERVABLE
+
+      actor_class = SolidObjects.registry.fetch(instance.actor_type)
+      actor_class.definition.broadcasts_observable_value?(observable_name)
+    end
   end
 end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,7 +113,7 @@ The supervisor starts configured worker, effect, reminder, and broadcast thread 
 
 ### Effect worker
 
-An effect worker claims due effect rows through the database coordination adapter, invokes a registered handler outside a database transaction, then records success or retryable failure. The handler receives the effect UUID as its idempotency key. Optional outcome messages are normal actor mailbox messages.
+An effect worker claims due effect rows through the database coordination adapter, invokes a registered handler outside a database transaction, then records success or retryable failure. The handler receives the effect UUID as its idempotency key. Optional outcome messages are normal actor mailbox messages and receive the effect ID, originally staged arguments, and result or error.
 
 ### Reminder scheduler
 
@@ -169,7 +169,8 @@ turn. `SolidObjects.mutable_copy` creates an independent mutable JSON value.
 `message` and `query` both execute as durable mailbox turns. A query may not
 mutate state. The executor detects query mutation and fails the message. An
 observable is a named projection of state used by server rendering and realtime
-updates; it is not independently persisted.
+updates. Its durable broadcast row stores the projected value by default;
+`broadcast: :invalidation` stores only an empty invalidation marker.
 
 Lifecycle hooks are deterministic local hooks:
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -92,8 +92,8 @@ Status/availability/ID drives delivery; completion/ID drives cleanup.
 ### `broadcasts`
 
 Durable observable-change outbox. The unique message/observable key prevents
-duplicate rows for one actor turn. Rows contain the observable JSON value and
-message/instance references used to derive invalidation metadata, never
+duplicate rows for one actor turn. Rows contain the observable JSON value, or
+`{}` for an invalidation-only observable, plus message/instance references used to derive invalidation metadata, never
 personalized rendered HTML. Claim and delivery indexes support retries and
 cleanup.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,6 +65,18 @@ assert_equal "completed", message.status
 Pass `roles: [:actors]` when a test intentionally wants to leave outboxes or
 reminders pending.
 
+Rails time travel does not move the database clock used by reminder claims. Run
+future reminders against an explicit test instant instead of updating runtime
+rows or sleeping:
+
+```ruby
+assert_equal 1, run_due_reminders(now: 5.minutes.from_now)
+assert_equal 1, drain_solid_objects(roles: [ :actors ])
+```
+
+The explicit instant controls due selection and recurring schedule advancement.
+Claim timestamps and stale-process recovery still use database time.
+
 `SolidObjects::TestHelper.reset_actors!` is also available for explicit suite
 boundaries. It deletes every actor-owned row itself rather than deleting actor
 instances and letting the database cascade remove the rest: SQLite has to be

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -65,6 +65,27 @@ listed in `observes:` raises `UnknownComponentDependency`. This keeps
 invalidation correct and prevents a partial from silently depending on state
 that cannot wake it.
 
+Observable values are shared projections. By default, each changed value is
+stored in the broadcast outbox and can be sent as a scalar Turbo replacement to
+every subscriber that passes `authorize_subscription`. Authorization to the
+actor stream is not a per-viewer projection.
+
+For a component dependency whose value must never enter the durable outbox or
+Action Cable frame, declare it invalidation-only:
+
+```ruby
+observable :player_one, broadcast: :invalidation do
+  player_in_seat(1)
+end
+```
+
+The runtime still compares the value around each successful turn and uses a
+change to refresh components, but stores `{}` and renders no scalar Turbo
+replacement. An invalidation-only observable therefore cannot be used as a
+scalar value such as `actor.player_one`. The component endpoint reads the
+latest committed value and authorizes it again; subscriber-specific state
+belongs in `broadcast_payload`.
+
 ```erb
 <ul>
   <% actor.recent_messages.each do |message| %>
@@ -416,7 +437,8 @@ component key, locals, or DOM ID.
 ## Broadcast durability
 
 The actor's fenced commit compares observables before and after the turn and
-inserts one broadcast row per changed value. The actor state, monotonic
+inserts one broadcast row per changed observable. Value-broadcast observables
+store the changed JSON value; invalidation-only observables store `{}`. The actor state, monotonic
 `state_revision`, message completion, and broadcast rows commit atomically. A
 rolled-back or fenced-out turn therefore cannot invalidate a component.
 
@@ -456,8 +478,8 @@ response revision fencing.
 ## Cost model
 
 The durable row cost is unchanged: one broadcast row per changed observable,
-containing its JSON value and the message/instance references needed to derive
-invalidation metadata. No rendered document is stored. Each affected component
+containing either its JSON value or an empty invalidation marker plus the
+message/instance references needed to derive invalidation metadata. No rendered document is stored. Each affected component
 adds one authorized GET and one partial render per non-coalesced state
 revision. A repeated keyed component adds one GET and render per key. Signed
 locals increase page and Cable subscription bytes but do not create durable

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,8 @@
 - Bounded activation passes, idle cache, hot-actor yield, and process records
 - At-least-once retries, terminal domain rejection, strict poison ordering,
   dead letters, and tail retry
-- Transactional effects with success/failure actor messages
+- Transactional effects with success/failure actor messages carrying the
+  originally staged arguments for callback correlation
 - Actor-to-actor asynchronous outbox delivery. Effects and broadcasts use
   portable status rows with polling indexes and database check constraints on
   status, which works on all three adapters; a future version may add narrow
@@ -23,8 +24,10 @@
   listed here while broken in that worker: the scheduler reached a constant the
   caller path happened to load, so reminders never fired in production and
   every in-process test still passed
-- Durable observable invalidations, scalar Turbo replacement, keyed ERB
-  components, signed component locals, and authorized replace or morph refresh
+- Durable value or invalidation-only observable broadcasts, scalar Turbo
+  replacement, keyed ERB components, signed component locals, and authorized
+  replace or morph refresh. Invalidation-only observables retain component
+  change detection while storing and broadcasting no projected value
 - Batched component refreshes: components sharing a signed `batch:` collapse to
   one browser request per revision, served as HTML frames in a JSON envelope
 - Personalized state payload broadcasts computed per subscriber under that
@@ -45,7 +48,8 @@
 - Bounded message/process pruning, actor-type opt-in instance expiration,
   graceful caller shutdown, committed state snapshots, and an opt-in Minitest
   helper that clears every actor-owned table itself rather than relying on the
-  database cascade, which a host application may not enforce
+  database cascade, which a host application may not enforce, and runs due
+  reminders against an explicit test time without moving the database clock
 - Supervisor role replacement: a role whose thread dies is restarted until
   shutdown is requested, and dead process records plus expired message and
   process history are pruned on their own intervals without an application

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,6 +36,14 @@ Opaque stream and DOM names reduce accidental disclosure but do not replace
 authorization. Signed stream tokens are readable by their recipient and prove
 integrity only.
 
+Every normal observable value is stored in the broadcast outbox and can reach
+every subscriber that passes `authorize_subscription` for the actor. Never put
+credentials, session identifiers, private cards, hidden library order, or any
+other subscriber-specific state in a value-broadcast observable. Declare a
+component dependency with `broadcast: :invalidation` when only change metadata
+may cross the shared stream, or use `broadcast_payload` for a projection that
+must be computed separately for each authorized connection.
+
 ## Serialization
 
 The built-in serializer accepts JSON-compatible data, normalizes keys to

--- a/examples/application/app/actors/shopping_cart_actor.rb
+++ b/examples/application/app/actors/shopping_cart_actor.rb
@@ -64,14 +64,14 @@ class ShoppingCartActor < SolidObjects::Actor
     )
   end
 
-  def payment_succeeded(effect_id:, result:)
+  def payment_succeeded(effect_id:, arguments:, result:)
     return unless checkout_status == "pending"
-    return unless result.fetch("payment_id") == payment_id
+    return unless arguments.fetch("payment_id") == payment_id
 
     self.checkout_status = "paid"
   end
 
-  def payment_failed(effect_id:, error:)
+  def payment_failed(effect_id:, arguments:, error:)
     return unless checkout_status == "pending"
 
     self.checkout_status = "payment_failed"

--- a/lib/solid_objects/actor.rb
+++ b/lib/solid_objects/actor.rb
@@ -52,9 +52,9 @@ module SolidObjects
         definition.add_query(name, block)
       end
 
-      # @rbs (Symbol | String) ?{ () -> untyped } -> ActorDefinition::Handler
-      def observable(name, &block)
-        definition.add_observable(name, block)
+      # @rbs (Symbol | String, ?broadcast: Symbol) ?{ () -> untyped } -> ActorDefinition::Handler
+      def observable(name, broadcast: :value, &block)
+        definition.add_observable(name, block, broadcast:)
       end
 
       # @rbs (Symbol | String) { (untyped, untyped) -> untyped } -> ActorDefinition::Handler
@@ -163,8 +163,9 @@ module SolidObjects
     # @rbs (Symbol | String, String, ?details: Hash[String | Symbol, untyped]) -> bot
     def reject(code, message, details: {})
       rejection_code = code.to_s
-      unless rejection_code.match?(/\A[a-z][a-z0-9_]*\z/)
-        raise ArgumentError, "rejection code must contain lowercase letters, digits, and underscores"
+      unless rejection_code.match?(/\A[A-Za-z_][A-Za-z0-9_]*\z/)
+        raise InvalidRejectionCode,
+          "invalid rejection code #{rejection_code.inspect}; expected a letter or underscore followed by letters, digits, or underscores"
       end
 
       raise Rejected.new(code: rejection_code, message:, details:)

--- a/lib/solid_objects/actor_channel.rb
+++ b/lib/solid_objects/actor_channel.rb
@@ -165,13 +165,13 @@ module SolidObjects
     def validate_scalar_observables!
       return unless scalar_observables
 
-      observables = SolidObjects
+      definition = SolidObjects
         .registry
         .fetch(reference.actor_type)
         .definition
-        .observables
       unknown = scalar_observables.find do |name|
-        !observables.key?(name.to_sym)
+        !definition.observables.key?(name.to_sym) ||
+          !definition.broadcasts_observable_value?(name)
       end
       return unless unknown
 
@@ -182,7 +182,10 @@ module SolidObjects
     def scalar_observable_names(snapshot)
       return scalar_observables if scalar_observables
 
-      snapshot.actor_class.definition.observables.keys.map(&:to_s)
+      definition = snapshot.actor_class.definition
+      definition.observables.keys.filter_map do |name|
+        name.to_s if definition.broadcasts_observable_value?(name)
+      end
     end
   end
 end

--- a/lib/solid_objects/actor_definition.rb
+++ b/lib/solid_objects/actor_definition.rb
@@ -9,6 +9,7 @@ module SolidObjects
     # @rbs @messages: Hash[Symbol, Handler]
     # @rbs @queries: Hash[Symbol, Handler]
     # @rbs @observables: Hash[Symbol, Handler]
+    # @rbs @observable_broadcasts: Hash[Symbol, Symbol]
     # @rbs @payload_broadcasts: Hash[Symbol, Handler]
     # @rbs @state_version: Integer
     # @rbs @state_migrations: Array[StateMigration]
@@ -33,6 +34,7 @@ module SolidObjects
       @messages = {}
       @queries = {}
       @observables = {}
+      @observable_broadcasts = {}
       @payload_broadcasts = {}
       @state_version = 1
       @state_migrations = []
@@ -76,15 +78,24 @@ module SolidObjects
       add_handler(collection: queries, name:, block:)
     end
 
-    # @rbs (Symbol | String, Proc?) -> Handler
-    def add_observable(name, block = nil)
+    # @rbs (Symbol | String, Proc?, broadcast: Symbol) -> Handler
+    def add_observable(name, block = nil, broadcast:)
       observable_name = name.to_sym
       raise InvalidActor, "#{observable_name.inspect} observable is already defined" if observables.key?(observable_name)
+      unless %i[value invalidation].include?(broadcast)
+        raise InvalidActor, "observable broadcast must be :value or :invalidation"
+      end
 
       observable_block = block || -> { state.fetch(observable_name) }
       Handler.new(name: observable_name, block: observable_block).tap do |handler|
         observables[observable_name] = handler
+        observable_broadcasts[observable_name] = broadcast
       end
+    end
+
+    # @rbs (Symbol | String) -> bool
+    def broadcasts_observable_value?(name)
+      observable_broadcasts.fetch(name.to_sym) == :value
     end
 
     # @rbs (Symbol | String, Proc) -> Handler
@@ -168,6 +179,7 @@ module SolidObjects
         copy.instance_variable_set(:@messages, messages.dup)
         copy.instance_variable_set(:@queries, queries.dup)
         copy.instance_variable_set(:@observables, observables.dup)
+        copy.instance_variable_set(:@observable_broadcasts, observable_broadcasts.dup)
         copy.instance_variable_set(:@payload_broadcasts, payload_broadcasts.dup)
         copy.instance_variable_set(:@state_version, state_version)
         copy.instance_variable_set(:@state_migrations, state_migrations.dup)
@@ -180,7 +192,7 @@ module SolidObjects
 
     private
 
-    attr_reader :attribute_queries, :method_messages
+    attr_reader :attribute_queries, :method_messages, :observable_broadcasts
 
     # @rbs (Symbol) -> Handler
     def add_method_message(name)

--- a/lib/solid_objects/actor_view.rb
+++ b/lib/solid_objects/actor_view.rb
@@ -24,8 +24,13 @@ module SolidObjects
     # @rbs (Symbol | String) -> untyped
     def value(name)
       observable_name = name.to_sym
-      handler = snapshot.actor_class.definition.observables[observable_name]
+      definition = snapshot.actor_class.definition
+      handler = definition.observables[observable_name]
       raise UnknownMessage, "unknown observable #{name.inspect}" unless handler
+      unless definition.broadcasts_observable_value?(observable_name)
+        raise ArgumentError,
+          "invalidation-only observable #{observable_name.inspect} cannot render as a scalar target"
+      end
 
       authorize_read!(observable_name)
       value = snapshot.observable_value(observable_name)

--- a/lib/solid_objects/effect_executor.rb
+++ b/lib/solid_objects/effect_executor.rb
@@ -153,7 +153,11 @@ module SolidObjects
           effect: locked_effect,
           operation: locked_effect.success_operation,
           outcome: "success",
-          arguments: { "effect_id" => locked_effect.effect_id, "result" => serialized_result }
+          arguments: {
+            "effect_id" => locked_effect.effect_id,
+            "arguments" => locked_effect.arguments,
+            "result" => serialized_result
+          }
         )
         locked_effect.update!(
           status: "completed",
@@ -191,7 +195,11 @@ module SolidObjects
             effect: locked_effect,
             operation: locked_effect.failure_operation,
             outcome: "failure",
-            arguments: { "effect_id" => locked_effect.effect_id, "error" => error_details }
+            arguments: {
+              "effect_id" => locked_effect.effect_id,
+              "arguments" => locked_effect.arguments,
+              "error" => error_details
+            }
           )
         end
         locked_effect.update!(

--- a/lib/solid_objects/errors.rb
+++ b/lib/solid_objects/errors.rb
@@ -205,6 +205,9 @@ module SolidObjects
   class UnknownCommitAction < NonRetryableError
   end
 
+  class InvalidRejectionCode < NonRetryableError
+  end
+
   class Rejected < Error
     # @rbs @code: String
     # @rbs @details: Hash[String, untyped]

--- a/lib/solid_objects/executor.rb
+++ b/lib/solid_objects/executor.rb
@@ -301,12 +301,18 @@ module SolidObjects
       end
 
       broadcasts.each do |observable_name, value|
+        stored_value = if observable_name != PayloadBroadcast::REVISION_OBSERVABLE &&
+            actor.class.definition.broadcasts_observable_value?(observable_name)
+          value
+        else
+          {}
+        end
         Broadcast.create!(
           message:,
           instance:,
           broadcast_id: SecureRandom.uuid,
           observable_name:,
-          value:,
+          value: stored_value,
           state_version: actor.class.state_version,
           activation_generation: activation.lease.generation,
           status: "pending",

--- a/lib/solid_objects/reminder_scheduler.rb
+++ b/lib/solid_objects/reminder_scheduler.rb
@@ -19,15 +19,16 @@ module SolidObjects
       @shutdown_requested = false
     end
 
-    # @rbs () -> bool
-    def run_once
+    # @rbs (?now: Time?) -> bool
+    def run_once(now: nil)
       return false if stopped?
 
+      now = normalize_test_time(now)
       process_registry.heartbeat
-      reminder = claim_next
+      reminder = claim_next(now:)
       return false unless reminder
 
-      enqueue(reminder).present?
+      enqueue(reminder, now:).present?
     rescue
       release(reminder) if reminder
       raise
@@ -74,13 +75,14 @@ module SolidObjects
 
     attr_reader :process_registry, :database_adapter
 
-    # @rbs () -> Reminder?
-    def claim_next
+    # @rbs (now: Time?) -> Reminder?
+    def claim_next(now:)
       database_adapter.transaction do
-        now = database_adapter.database_now
-        stale_at = now - SolidObjects.configuration.process_alive_threshold
+        database_now = database_adapter.database_now
+        due_at = now || database_now
+        stale_at = database_now - SolidObjects.configuration.process_alive_threshold
         relation = Reminder
-          .where(status: "scheduled", next_run_at: ..now)
+          .where(status: "scheduled", next_run_at: ..due_at)
           .where("claimed_by IS NULL OR claimed_at <= ?", stale_at)
           .order(:next_run_at, :id)
         reminder = database_adapter.lock_candidates(relation).first
@@ -88,14 +90,14 @@ module SolidObjects
 
         reminder.update!(
           claimed_by: process_registry.process_record.id,
-          claimed_at: now
+          claimed_at: database_now
         )
         reminder
       end
     end
 
-    # @rbs (Reminder) -> MessageReference?
-    def enqueue(reminder)
+    # @rbs (Reminder, now: Time?) -> MessageReference?
+    def enqueue(reminder, now:)
       actor_class = SolidObjects.registry.fetch(reminder.actor_type)
       unless actor_class.definition.messages.key?(reminder.operation.to_sym)
         raise UnknownMessage, "unknown reminder operation #{reminder.operation.inspect}"
@@ -109,7 +111,7 @@ module SolidObjects
         locked_reminder = Reminder.lock.find_by(id: reminder.id)
         next unless locked_reminder
         verify_claim!(locked_reminder)
-        now = database_adapter.database_now
+        schedule_now = now || database_adapter.database_now
         message = mailbox.enqueue_in_transaction(
           reference: Reference.new(actor_type: instance.actor_type, actor_id: instance.actor_id),
           operation: locked_reminder.operation,
@@ -122,7 +124,7 @@ module SolidObjects
         locked_reminder.update!(
           status: recurring ? "scheduled" : "completed",
           occurrence: locked_reminder.occurrence + 1,
-          next_run_at: recurring ? next_run_at(locked_reminder, now) : locked_reminder.next_run_at,
+          next_run_at: recurring ? next_run_at(locked_reminder, schedule_now) : locked_reminder.next_run_at,
           claimed_by: nil,
           claimed_at: nil
         )
@@ -163,6 +165,18 @@ module SolidObjects
 
       missed_intervals = ((now - next_run) / interval).floor + 1
       next_run + (missed_intervals * interval)
+    end
+
+    # @rbs (Time?) -> Time?
+    def normalize_test_time(now)
+      return unless now
+
+      time = now.to_time
+      return time if time.to_f.finite?
+
+      raise ArgumentError
+    rescue ArgumentError, NoMethodError, RangeError
+      raise ArgumentError, "reminder test time must be a valid time"
     end
   end
 end

--- a/lib/solid_objects/test_helper.rb
+++ b/lib/solid_objects/test_helper.rb
@@ -68,6 +68,22 @@ module SolidObjects
       runners&.uniq&.each(&:stop)
     end
 
+    # @rbs (now: Time, ?max_reminders: Integer) -> Integer
+    def run_due_reminders(now:, max_reminders: 10_000)
+      unless max_reminders.is_a?(Integer) && max_reminders.positive?
+        raise ArgumentError, "max_reminders must be a positive integer"
+      end
+
+      scheduler = ReminderScheduler.new
+      processed = 0
+      while processed < max_reminders && scheduler.run_once(now:)
+        processed += 1
+      end
+      processed
+    ensure
+      scheduler&.stop
+    end
+
     private
 
     # @rbs (Array[Symbol]) -> Array[Worker | EffectExecutor | ReminderScheduler | BroadcastExecutor]

--- a/lib/solid_objects/turbo_stream_renderer.rb
+++ b/lib/solid_objects/turbo_stream_renderer.rb
@@ -16,14 +16,14 @@ module SolidObjects
         actor_type: broadcast.instance.actor_type,
         actor_id: broadcast.instance.actor_id
       )
-      stream = if broadcast.observable_name == PayloadBroadcast::REVISION_OBSERVABLE
-        ""
-      else
+      stream = if broadcast.broadcasts_value?
         observable_value(
           reference:,
           name: broadcast.observable_name,
           value: broadcast.value
         )
+      else
+        ""
       end
       metadata = Base64.urlsafe_encode64(
         JSON.generate(

--- a/lib/solid_objects/version.rb
+++ b/lib/solid_objects/version.rb
@@ -1,5 +1,5 @@
 # rbs_inline: enabled
 
 module SolidObjects
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/sig/generated/lib/solid_objects/actor.rbs
+++ b/sig/generated/lib/solid_objects/actor.rbs
@@ -87,8 +87,8 @@ module SolidObjects
     # @rbs (Symbol | String) { (*untyped, **untyped) -> untyped } -> ActorDefinition::Handler
     def self.query: (Symbol | String) { (*untyped, **untyped) -> untyped } -> ActorDefinition::Handler
 
-    # @rbs (Symbol | String) ?{ () -> untyped } -> ActorDefinition::Handler
-    def self.observable: (Symbol | String) ?{ () -> untyped } -> ActorDefinition::Handler
+    # @rbs (Symbol | String, ?broadcast: Symbol) ?{ () -> untyped } -> ActorDefinition::Handler
+    def self.observable: (Symbol | String, ?broadcast: Symbol) ?{ () -> untyped } -> ActorDefinition::Handler
 
     # @rbs (Symbol | String) { (untyped, untyped) -> untyped } -> ActorDefinition::Handler
     def self.broadcast_payload: (Symbol | String) { (untyped, untyped) -> untyped } -> ActorDefinition::Handler

--- a/sig/generated/lib/solid_objects/actor_definition.rbs
+++ b/sig/generated/lib/solid_objects/actor_definition.rbs
@@ -44,6 +44,8 @@ module SolidObjects
 
     @payload_broadcasts: Hash[Symbol, Handler]
 
+    @observable_broadcasts: Hash[Symbol, Symbol]
+
     @observables: Hash[Symbol, Handler]
 
     @queries: Hash[Symbol, Handler]
@@ -82,8 +84,11 @@ module SolidObjects
     # @rbs (Symbol | String, Proc) -> Handler
     def add_query: (Symbol | String, Proc) -> Handler
 
-    # @rbs (Symbol | String, Proc?) -> Handler
-    def add_observable: (Symbol | String, Proc?) -> Handler
+    # @rbs (Symbol | String, Proc?, broadcast: Symbol) -> Handler
+    def add_observable: (Symbol | String, Proc?, broadcast: Symbol) -> Handler
+
+    # @rbs (Symbol | String) -> bool
+    def broadcasts_observable_value?: (Symbol | String) -> bool
 
     # @rbs (Symbol | String, Proc) -> Handler
     def add_payload_broadcast: (Symbol | String, Proc) -> Handler
@@ -108,6 +113,8 @@ module SolidObjects
     attr_reader attribute_queries: untyped
 
     attr_reader method_messages: untyped
+
+    attr_reader observable_broadcasts: untyped
 
     # @rbs (Symbol) -> Handler
     def add_method_message: (Symbol) -> Handler

--- a/sig/generated/lib/solid_objects/errors.rbs
+++ b/sig/generated/lib/solid_objects/errors.rbs
@@ -179,6 +179,9 @@ module SolidObjects
   class UnknownCommitAction < NonRetryableError
   end
 
+  class InvalidRejectionCode < NonRetryableError
+  end
+
   class Rejected < Error
     @code: String
 

--- a/sig/generated/lib/solid_objects/reminder_scheduler.rbs
+++ b/sig/generated/lib/solid_objects/reminder_scheduler.rbs
@@ -13,8 +13,8 @@ module SolidObjects
     # @rbs (?process_registry: ProcessRegistry, ?database_adapter: DatabaseAdapter) -> void
     def initialize: (?process_registry: ProcessRegistry, ?database_adapter: DatabaseAdapter) -> void
 
-    # @rbs () -> bool
-    def run_once: () -> bool
+    # @rbs (?now: Time?) -> bool
+    def run_once: (?now: Time?) -> bool
 
     # @rbs () -> void
     def stop: () -> void
@@ -37,11 +37,11 @@ module SolidObjects
 
     attr_reader database_adapter: untyped
 
-    # @rbs () -> Reminder?
-    def claim_next: () -> Reminder?
+    # @rbs (now: Time?) -> Reminder?
+    def claim_next: (now: Time?) -> Reminder?
 
-    # @rbs (Reminder) -> MessageReference?
-    def enqueue: (Reminder) -> MessageReference?
+    # @rbs (Reminder, now: Time?) -> MessageReference?
+    def enqueue: (Reminder, now: Time?) -> MessageReference?
 
     # @rbs (Reminder) -> void
     def release: (Reminder) -> void
@@ -51,5 +51,8 @@ module SolidObjects
 
     # @rbs (Reminder, Time) -> Time
     def next_run_at: (Reminder, Time) -> Time
+
+    # @rbs (Time?) -> Time?
+    def normalize_test_time: (Time?) -> Time?
   end
 end

--- a/sig/generated/lib/solid_objects/test_helper.rbs
+++ b/sig/generated/lib/solid_objects/test_helper.rbs
@@ -26,6 +26,9 @@ module SolidObjects
     # @rbs (?roles: Array[Symbol], ?max_passes: Integer) -> Integer
     def drain_solid_objects: (?roles: Array[Symbol], ?max_passes: Integer) -> Integer
 
+    # @rbs (now: Time, ?max_reminders: Integer) -> Integer
+    def run_due_reminders: (now: Time, ?max_reminders: Integer) -> Integer
+
     private
 
     # @rbs (Array[Symbol]) -> Array[Worker | EffectExecutor | ReminderScheduler | BroadcastExecutor]

--- a/sig/generated/models/solid_objects/broadcast.rbs
+++ b/sig/generated/models/solid_objects/broadcast.rbs
@@ -2,5 +2,7 @@
 
 module SolidObjects
   class Broadcast < Record
+    # @rbs () -> bool
+    def broadcasts_value?: () -> bool
   end
 end

--- a/test/integration/actor_channel_test.rb
+++ b/test/integration/actor_channel_test.rb
@@ -19,10 +19,12 @@ class ActorChannelTest < ActionCable::Channel::TestCase
     attribute :missing, default: 0
     attribute :status, default: "open"
     attribute :unrelated, default: 0
+    attribute :secret, default: nil
 
     observable :missing
     observable :status
     observable :unrelated
+    observable :secret, broadcast: :invalidation
 
     def update_all
       self.missing += 1
@@ -32,6 +34,10 @@ class ActorChannelTest < ActionCable::Channel::TestCase
 
     def update_missing
       self.missing += 1
+    end
+
+    def update_secret(secret:)
+      self.secret = secret
     end
   end
 
@@ -492,6 +498,32 @@ class ActorChannelTest < ActionCable::Channel::TestCase
 
     assert_empty component_refreshes(reference, :player, key: "alice")
     assert_equal 1, component_refreshes(reference, :player, key: "bob").length
+  ensure
+    worker&.stop
+  end
+
+  test "refreshes components without transmitting invalidation-only values" do
+    reference = ChannelActor.ref("actor-1")
+    SolidObjects.configuration.authorize_subscription = ->(**) { true }
+    subscribe(
+      token: SolidObjects::StreamToken.generate(reference, observables: []),
+      components: JSON.generate(
+        [ component_token(reference, component_name: "private", dependencies: %w[secret], revision: 0) ]
+      )
+    )
+    reference.async.update_secret(secret: "Black Lotus")
+    worker = SolidObjects::Worker.new
+    worker.run_until_idle
+    broadcast = SolidObjects::Broadcast.find_by!(observable_name: "secret")
+
+    subscription.__send__(
+      :receive_broadcast,
+      SolidObjects::TurboStreamRenderer.observable(broadcast)
+    )
+
+    assert_equal({}, broadcast.value)
+    assert_equal 1, component_refreshes(reference, :private).length
+    refute transmissions.any? { |transmission| transmission.include?("Black Lotus") }
   ensure
     worker&.stop
   end

--- a/test/integration/actor_helper_test.rb
+++ b/test/integration/actor_helper_test.rb
@@ -21,6 +21,9 @@ class ActorHelperTest < ActionView::TestCase
 
     observable :items
     observable :status
+    observable :private_status, broadcast: :invalidation do
+      status
+    end
 
     def replace_items(items:)
       self.items = items
@@ -86,6 +89,15 @@ class ActorHelperTest < ActionView::TestCase
     token = html[/data-token="([^"]+)"/, 1]
     identity = SolidObjects::StreamToken.verify(token)
     assert_equal [ "items_count" ], identity.fetch("observables")
+  end
+
+  test "invalidation-only observables do not render as scalar targets" do
+    reference = CartActor.ref("alice")
+
+    error = assert_raises(ArgumentError) do
+      solid_object(reference) { |actor| actor.private_status }
+    end
+    assert_includes error.message, "invalidation-only"
   end
 
   test "authorizes initial actor state reads" do

--- a/test/integration/broadcasts_test.rb
+++ b/test/integration/broadcasts_test.rb
@@ -20,6 +20,18 @@ class BroadcastsTest < ActiveSupport::TestCase
     end
   end
 
+  class PrivateRoomActor < SolidObjects::Actor
+    actor_type "private-broadcast-room"
+
+    attribute :secret, default: nil
+
+    observable :secret, broadcast: :invalidation
+
+    def reveal(secret:)
+      self.secret = secret
+    end
+  end
+
   setup do
     SolidObjects.configuration.retry_delay = ->(_attempt) { 0 }
   end
@@ -49,6 +61,23 @@ class BroadcastsTest < ActiveSupport::TestCase
 
     assert_empty SolidObjects::Broadcast.all
     assert_equal 0, SolidObjects::Instance.first.state_revision
+  ensure
+    worker&.stop
+  end
+
+  test "invalidation-only observables do not persist or render their values" do
+    PrivateRoomActor.ref("one").async.reveal(secret: "Black Lotus")
+    worker = SolidObjects::Worker.new
+
+    worker.run_until_idle
+
+    broadcast = SolidObjects::Broadcast.find_by!(observable_name: "secret")
+    assert_equal({}, broadcast.value)
+
+    stream = SolidObjects::TurboStreamRenderer.observable(broadcast)
+    refute_includes stream, "Black Lotus"
+    refute_includes stream, "turbo-stream"
+    refute_nil SolidObjects::TurboStreamRenderer.invalidation(stream)
   ensure
     worker&.stop
   end

--- a/test/integration/destroy_test.rb
+++ b/test/integration/destroy_test.rb
@@ -22,7 +22,7 @@ class DestroyTest < ActiveSupport::TestCase
       emit :record_counter, value:, on_success: :recorded
     end
 
-    def recorded(effect_id:, result:)
+    def recorded(effect_id:, arguments:, result:)
       self.value += result.fetch("amount")
     end
 
@@ -51,18 +51,18 @@ class DestroyTest < ActiveSupport::TestCase
     # @rbs (claimed: Thread::Queue, release: Thread::Queue) -> void
     def initialize(claimed:, release:)
       @claimed = claimed
-      @release = release
+      @release_queue = release
       super()
     end
 
     private
 
-    attr_reader :claimed, :release
+    attr_reader :claimed, :release_queue
 
-    # @rbs (SolidObjects::Reminder) -> SolidObjects::MessageReference?
-    def enqueue(reminder)
+    # @rbs (SolidObjects::Reminder, now: Time?) -> SolidObjects::MessageReference?
+    def enqueue(reminder, now:)
       claimed << true
-      release.pop
+      release_queue.pop
       super
     end
   end

--- a/test/integration/effects_test.rb
+++ b/test/integration/effects_test.rb
@@ -28,12 +28,12 @@ class EffectsTest < ActiveSupport::TestCase
       )
     end
 
-    def payment_charged(effect_id:, result:)
-      self.status = "#{effect_id}:#{result.fetch("provider_id")}"
+    def payment_charged(effect_id:, arguments:, result:)
+      self.status = "#{effect_id}:#{arguments.fetch("payment_id")}:#{result.fetch("provider_id")}"
     end
 
-    def payment_failed(effect_id:, error:)
-      self.status = "#{effect_id}:#{error.fetch("class")}"
+    def payment_failed(effect_id:, arguments:, error:)
+      self.status = "#{effect_id}:#{arguments.fetch("payment_id")}:#{error.fetch("class")}"
     end
   end
 
@@ -110,10 +110,11 @@ class EffectsTest < ActiveSupport::TestCase
     )
     assert_equal "payment_charged", result_message.operation
     assert_equal effect.effect_id, result_message.arguments.fetch("effect_id")
+    assert_equal effect.arguments, result_message.arguments.fetch("arguments")
 
     worker.run_until_idle
     assert_equal(
-      "#{effect.effect_id}:provider-1",
+      "#{effect.effect_id}:payment-1:provider-1",
       SolidObjects::Instance.find_by!(actor_id: "order-1").state.fetch("status")
     )
   ensure
@@ -137,7 +138,14 @@ class EffectsTest < ActiveSupport::TestCase
       idempotency_key: "effect:#{effect.effect_id}:failure"
     )
     assert_equal "payment_failed", failure_message.operation
+    assert_equal effect.arguments, failure_message.arguments.fetch("arguments")
     assert_equal "RuntimeError", failure_message.arguments.dig("error", "class")
+
+    worker.run_until_idle
+    assert_equal(
+      "#{effect.effect_id}:payment-1:RuntimeError",
+      SolidObjects::Instance.find_by!(actor_id: "order-1").state.fetch("status")
+    )
   ensure
     effect_executor&.stop
     worker&.stop

--- a/test/integration/public_test_helper_test.rb
+++ b/test/integration/public_test_helper_test.rb
@@ -24,6 +24,14 @@ class PublicTestHelperTest < ActiveSupport::TestCase
     def finish_work
       self.value += 1
     end
+
+    def start_future_work(run_at:)
+      schedule(at: Time.iso8601(run_at)).finish_work
+    end
+
+    def start_recurring_work(run_at:)
+      schedule(at: Time.iso8601(run_at), every: 1.minute).finish_work
+    end
   end
 
   class ActorTestCase < ActiveSupport::TestCase
@@ -120,6 +128,34 @@ class PublicTestHelperTest < ActiveSupport::TestCase
     end
 
     assert_includes error.message, "unknown"
+  end
+
+  test "run due reminders uses an explicit test time" do
+    test_case = ActorTestCase.new("unused")
+    run_at = 5.minutes.from_now
+    reference = HelperActor.ref("future-work")
+    reference.async.start_future_work(run_at: run_at.iso8601(6))
+    test_case.drain_solid_objects(roles: [ :actors ])
+
+    assert_equal 0, test_case.run_due_reminders(now: run_at - 1.second)
+    assert_equal 1, test_case.run_due_reminders(now: run_at)
+    assert_equal 1, test_case.drain_solid_objects(roles: [ :actors ])
+    assert_equal({ "value" => 1 }, SolidObjects::Instance.find_by!(actor_id: "future-work").state)
+  end
+
+  test "run due reminders advances recurrence from the explicit test time" do
+    test_case = ActorTestCase.new("unused")
+    run_at = 5.minutes.from_now
+    reference = HelperActor.ref("recurring-work")
+    reference.async.start_recurring_work(run_at: run_at.iso8601(6))
+    test_case.drain_solid_objects(roles: [ :actors ])
+
+    test_now = run_at + 5.minutes
+    assert_equal 1, test_case.run_due_reminders(now: test_now)
+
+    reminder = SolidObjects::Reminder.find_by!(actor_id: "recurring-work")
+    assert_operator reminder.next_run_at, :>, test_now
+    assert_operator reminder.next_run_at, :<=, test_now + 1.minute
   end
 
   private

--- a/test/integration/synchronous_invocation_test.rb
+++ b/test/integration/synchronous_invocation_test.rb
@@ -20,6 +20,10 @@ class SynchronousInvocationTest < ActiveSupport::TestCase
 
       self.value += 1
     end
+
+    def reject_with(code:)
+      reject code, "The rejection code was accepted"
+    end
   end
 
   class BlockingActor < SolidObjects::Actor
@@ -809,6 +813,30 @@ class SynchronousInvocationTest < ActiveSupport::TestCase
     assert_equal "rejected", message_reference.status
     assert_equal "validation_failed", SolidObjects::Message.find(message_reference.id).rejection.fetch("code")
     assert_empty SolidObjects::DeadLetter.all
+  ensure
+    worker&.stop
+  end
+
+  test "reject accepts identifier-style symbol codes" do
+    error = assert_raises(SolidObjects::Rejected) do
+      CounterActor.ref("symbol-rejection").reject_with(code: :validationFailed)
+    end
+
+    assert_equal "validationFailed", error.code
+  end
+
+  test "an invalid rejection code fails without retrying" do
+    SolidObjects.configuration.max_attempts = 3
+    SolidObjects.configuration.retry_delay = ->(_attempt) { 0 }
+    message_reference = CounterActor.ref("invalid-rejection").async.reject_with(code: "not-valid")
+    worker = SolidObjects::Worker.new
+
+    assert_equal 1, worker.run_until_idle
+
+    message = SolidObjects::Message.find(message_reference.id)
+    assert_equal 1, message.attempt_count
+    assert_equal "dead", message_reference.status
+    assert_equal "SolidObjects::InvalidRejectionCode", message.dead_letter.exception_class
   ensure
     worker&.stop
   end

--- a/test/unit/actor_test.rb
+++ b/test/unit/actor_test.rb
@@ -133,6 +133,16 @@ class ActorTest < ActiveSupport::TestCase
     assert_equal({ "count" => 3 }, actor.observable_values)
   end
 
+  test "rejects unknown observable broadcast modes" do
+    error = assert_raises(SolidObjects::InvalidActor) do
+      Class.new(SolidObjects::Actor) do
+        observable :value, broadcast: :secret
+      end
+    end
+
+    assert_includes error.message, ":value or :invalidation"
+  end
+
   test "rejects synchronous invocations from actor context" do
     reference = CartActor.ref("other")
 


### PR DESCRIPTION
## Summary

- add `broadcast: :invalidation` for observable dependencies that must refresh components without storing or broadcasting their projected value
- include the originally staged `arguments:` in effect success and failure callbacks
- accept identifier-style rejection codes and make malformed codes terminal through `InvalidRejectionCode`
- add `run_due_reminders(now:)` for deterministic database-clock reminder tests
- document the security boundary and prepare version 0.12.1

## Root cause

Normal observables did not express whether their value was safe to persist and place in the Action Cable broadcast payload. The renderer therefore built a scalar replacement for every changed observable, even when the application used it only as a component invalidation signal.

Effect result messages also omitted the staged arguments, malformed rejection codes raised a retryable `ArgumentError`, and Rails time travel could not move the database clock used by reminder claims.

## API, security, and compatibility

- Existing observables keep `broadcast: :value` behavior by default.
- `broadcast: :invalidation` stores `{}`, renders metadata only, refreshes dependent components, and cannot be used as a scalar target.
- Effect callbacks now require `arguments:`; this is a deliberate breaking callback change.
- Ruby `reject(code, message, details:)` continues to accept strings and symbols. Codes now follow identifier grammar, including camelCase.
- No database migration is required.
- The roadmap, security guide, realtime guide, example actor, generated RBS, changelog, version, and lockfile are updated together.

## Red/green evidence

The focused tests failed before implementation with the expected contract gaps:

- `ArgumentError: wrong number of arguments (given 2, expected 1)` for `observable ..., broadcast: :invalidation`
- `KeyError: key not found: "arguments"` for an effect result message
- `NoMethodError: undefined method 'run_due_reminders'` for the public test helper
- a retry-driven `SolidObjects::SyncTimeout` for an accepted camelCase rejection code
- no error when rendering an invalidation-only observable as a scalar target

All focused regression suites pass after the implementation.

## Validation

- `bundle exec rake` — 436 tests, 1,467 assertions, 0 failures, 0 errors, 14 optional-adapter skips; Standard Ruby, RuboCop, RBS validation, Steep, and Brakeman all pass
- `SOLID_OBJECTS_DATABASE_URL=postgresql://... bundle exec rake test` — 436 tests, 1,444 assertions, 0 failures, 0 errors, 15 optional-service skips
- `gem build solid_objects.gemspec --output /tmp/solid_objects-0.12.1.gem` — built version 0.12.1 successfully

MySQL and Trilogy were not rerun locally because the available unrelated service rejected the dedicated test credentials; the repository CI matrix remains the validation path for those clients.
