### PR TITLE
Make observables invalidation-only by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.13.0 - 2026-08-13
+
+- **Breaking:** make observables invalidation-only by default. An ordinary
+  `observable :status` continues to detect changes and refresh reactive
+  components, but persists `{}` and sends no scalar value over Action Cable.
+  Declare `observable :status, broadcast: :value` to deliberately store and
+  share the projection with every authorized actor subscriber. Applications
+  upgrading from 0.12.x must add that opt-in to observables rendered as scalar
+  targets.
+
 ## 0.12.1 - 2026-08-13
 
 - Add invalidation-only observables with `broadcast: :invalidation`. They still

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_objects (0.12.1)
+    solid_objects (0.13.0)
       actioncable (>= 8.0)
       actionpack (>= 8.0)
       actionview (>= 8.0)
@@ -383,7 +383,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  solid_objects (0.12.1)
+  solid_objects (0.13.0)
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ class ChatRoom < SolidObjects::Actor
   attribute :recent_messages, default: -> { [] }
   attribute :status, default: "open"
 
-  observable :message_count do
+  observable :message_count, broadcast: :value do
     recent_messages.length
   end
 
@@ -205,20 +205,22 @@ dependencies changes:
 <% end %>
 ```
 
-An observable's value is shared with every authorized subscriber by default
-and is stored in `solid_objects_broadcasts`. Use an invalidation-only observable
-for component dependencies whose value is private or subscriber-specific:
+Observables are invalidation-only by default. Their values remain available to
+authorized component rendering, while durable rows and Action Cable frames
+carry only change metadata. Explicitly opt a scalar observable into sharing its
+value with every authorized actor subscriber:
 
 ```ruby
-observable :player_one, broadcast: :invalidation do
-  player_in_seat(1)
+observable :message_count, broadcast: :value do
+  recent_messages.length
 end
 ```
 
-Its value is still available to the authorized component renderer, but the
-durable row and Action Cable frame carry only invalidation metadata. It cannot
-be rendered as a scalar `<span>`. Put per-viewer state in `broadcast_payload`,
-which computes a fresh projection for each connection.
+Only `broadcast: :value` observables can render as scalar `<span>` targets.
+Their changed values are stored in `solid_objects_broadcasts` and can reach
+every subscriber that passes `authorize_subscription` for the actor. Put
+per-viewer state in `broadcast_payload`, which computes a fresh projection for
+each connection.
 
 Component names can repeat when each instance has a stable key. Signed
 JSON-compatible locals let one conventional partial render the matching
@@ -530,7 +532,7 @@ class ShoppingCart < SolidObjects::Actor
     end
   end
 
-  observable :items_count do
+  observable :items_count, broadcast: :value do
     items.sum { |item| item.fetch("quantity") }
   end
 end

--- a/docs/adr/0009-realtime-updates.md
+++ b/docs/adr/0009-realtime-updates.md
@@ -9,7 +9,11 @@ Action Cable broadcasts are online-only. A transaction can roll back, a broadcas
 
 ## Decision
 
-The executor evaluates declared observables before and after a successful message. Changed values create broadcast outbox records inside the message commit. A broadcast worker delivers Turbo Stream replacements after commit.
+The executor evaluates declared observables before and after a successful
+message. Changes create invalidation-only broadcast outbox records inside the
+message commit by default. An explicit `broadcast: :value` declaration stores
+the projection and lets a broadcast worker deliver scalar Turbo Stream
+replacements after commit.
 
 One `solid_object` block creates one signed Action Cable subscription and
 contains stable targets for multiple observables and components. Component

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,8 +169,9 @@ turn. `SolidObjects.mutable_copy` creates an independent mutable JSON value.
 `message` and `query` both execute as durable mailbox turns. A query may not
 mutate state. The executor detects query mutation and fails the message. An
 observable is a named projection of state used by server rendering and realtime
-updates. Its durable broadcast row stores the projected value by default;
-`broadcast: :invalidation` stores only an empty invalidation marker.
+updates. Its durable broadcast row stores only an empty invalidation marker by
+default. `broadcast: :value` explicitly opts into storing and sharing the
+projected value.
 
 Lifecycle hooks are deterministic local hooks:
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -53,9 +53,9 @@ Component partials receive the resolved value as the
 `authorization_context` local, allowing two authorized viewers to render
 different projections. Responses use `Cache-Control: private, no-store`.
 Durable outbox rows and shared Cable messages never contain component HTML.
-The stream token also signs the scalar observable targets rendered into that
-specific scope. Component-only dependencies send invalidation metadata but not
-their state value to the browser.
+The stream token also signs explicitly value-broadcast scalar observable
+targets rendered into that specific scope. Default component dependencies send
+invalidation metadata but not their state value to the browser.
 
 Keyed components sign their `component_key` and declared JSON-compatible
 locals into the component token. Initial rendering and every refresh pass those

--- a/docs/correctness.md
+++ b/docs/correctness.md
@@ -131,9 +131,9 @@ rendering invokes query authorization, Cable separately invokes subscription
 authorization, and the cookie-bearing refresh request invokes query
 authorization again for the component name and every dependency.
 
-The actor stream token separately signs the scalar observable targets rendered
-into its scope. A component dependency that has no scalar target carries only
-its name and revision over Cable, not its serialized value.
+The actor stream token separately signs the explicitly value-broadcast scalar
+observable targets rendered into its scope. A default component dependency
+carries only its name and revision over Cable, not its serialized value.
 
 Cable compares `(instance_id, state_revision)` pairs, coalesces dependencies
 changed by the same turn, and ignores an older pair after a newer one. A new

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -92,10 +92,11 @@ Status/availability/ID drives delivery; completion/ID drives cleanup.
 ### `broadcasts`
 
 Durable observable-change outbox. The unique message/observable key prevents
-duplicate rows for one actor turn. Rows contain the observable JSON value, or
-`{}` for an invalidation-only observable, plus message/instance references used to derive invalidation metadata, never
-personalized rendered HTML. Claim and delivery indexes support retries and
-cleanup.
+duplicate rows for one actor turn. Rows contain `{}` for the default
+invalidation-only observable, or the observable JSON value after an explicit
+`broadcast: :value` opt-in, plus message/instance references used to derive
+invalidation metadata, never personalized rendered HTML. Claim and delivery
+indexes support retries and cleanup.
 
 ### `dead_letters`
 

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -13,12 +13,19 @@
 <% end %>
 ```
 
-Every observable gets a stable opaque DOM ID. Multiple values share the one
-actor subscription and Action Cable multiplexes actor subscriptions over the
-browser's physical WebSocket.
+Every value-broadcast observable gets a stable opaque DOM ID. Multiple values
+share the one actor subscription and Action Cable multiplexes actor
+subscriptions over the browser's physical WebSocket.
 
 Scalar observable calls such as `cart.items_count` render stable `<span>`
-targets. Their broadcast remains a direct escaped text replacement.
+targets. Their broadcast remains a direct escaped text replacement, and their
+declaration must explicitly opt in with `broadcast: :value`:
+
+```ruby
+observable :items_count, broadcast: :value do
+  items.sum { |item| item.fetch("quantity") }
+end
+```
 
 A reactive component declares one or more explicit observable dependencies.
 `actor.component(:summary, observes: ...)` resolves the host partial by
@@ -65,16 +72,12 @@ listed in `observes:` raises `UnknownComponentDependency`. This keeps
 invalidation correct and prevents a partial from silently depending on state
 that cannot wake it.
 
-Observable values are shared projections. By default, each changed value is
-stored in the broadcast outbox and can be sent as a scalar Turbo replacement to
-every subscriber that passes `authorize_subscription`. Authorization to the
-actor stream is not a per-viewer projection.
-
-For a component dependency whose value must never enter the durable outbox or
-Action Cable frame, declare it invalidation-only:
+Observables are invalidation-only by default. Their values never enter the
+durable outbox or Action Cable frame, so the ordinary declaration is the safe
+choice for component dependencies:
 
 ```ruby
-observable :player_one, broadcast: :invalidation do
+observable :player_one do
   player_in_seat(1)
 end
 ```
@@ -85,6 +88,10 @@ replacement. An invalidation-only observable therefore cannot be used as a
 scalar value such as `actor.player_one`. The component endpoint reads the
 latest committed value and authorizes it again; subscriber-specific state
 belongs in `broadcast_payload`.
+
+Use `broadcast: :value` only for a shared projection that may be stored and
+sent to every subscriber that passes `authorize_subscription`. Authorization
+to the actor stream is not a per-viewer projection.
 
 ```erb
 <ul>
@@ -437,8 +444,9 @@ component key, locals, or DOM ID.
 ## Broadcast durability
 
 The actor's fenced commit compares observables before and after the turn and
-inserts one broadcast row per changed observable. Value-broadcast observables
-store the changed JSON value; invalidation-only observables store `{}`. The actor state, monotonic
+inserts one broadcast row per changed observable. Invalidation-only
+observables, the default, store `{}`. Observables declared with
+`broadcast: :value` store the changed JSON value. The actor state, monotonic
 `state_revision`, message completion, and broadcast rows commit atomically. A
 rolled-back or fenced-out turn therefore cannot invalidate a component.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,10 +24,11 @@
   listed here while broken in that worker: the scheduler reached a constant the
   caller path happened to load, so reminders never fired in production and
   every in-process test still passed
-- Durable value or invalidation-only observable broadcasts, scalar Turbo
-  replacement, keyed ERB components, signed component locals, and authorized
-  replace or morph refresh. Invalidation-only observables retain component
-  change detection while storing and broadcasting no projected value
+- Durable invalidation-only observable broadcasts by default, explicit
+  `broadcast: :value` scalar Turbo replacement, keyed ERB components, signed
+  component locals, and authorized replace or morph refresh. Default
+  observables retain component change detection while storing and broadcasting
+  no projected value
 - Batched component refreshes: components sharing a signed `batch:` collapse to
   one browser request per revision, served as HTML frames in a JSON envelope
 - Personalized state payload broadcasts computed per subscriber under that

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,13 +36,13 @@ Opaque stream and DOM names reduce accidental disclosure but do not replace
 authorization. Signed stream tokens are readable by their recipient and prove
 integrity only.
 
-Every normal observable value is stored in the broadcast outbox and can reach
-every subscriber that passes `authorize_subscription` for the actor. Never put
-credentials, session identifiers, private cards, hidden library order, or any
-other subscriber-specific state in a value-broadcast observable. Declare a
-component dependency with `broadcast: :invalidation` when only change metadata
-may cross the shared stream, or use `broadcast_payload` for a projection that
-must be computed separately for each authorized connection.
+Observables are invalidation-only by default, so their durable rows and shared
+actor stream carry no projected value. `broadcast: :value` deliberately stores
+the value in the broadcast outbox and may send it to every subscriber that
+passes `authorize_subscription` for the actor. Never opt credentials, session
+identifiers, private cards, hidden library order, or any other
+subscriber-specific state into value broadcasting. Use `broadcast_payload` for
+a projection that must be computed separately for each authorized connection.
 
 ## Serialization
 

--- a/examples/application/README.md
+++ b/examples/application/README.md
@@ -10,8 +10,8 @@ key. The chat actor also gives every submitted chat message a caller-generated
 message ID and checks that ID in durable actor state, because actor handlers may
 be redelivered.
 
-The views demonstrate scalar observable replacement and a live chat-message
-ERB component. The chat component receives `recent_messages` as an ordinary
-Ruby array, rerenders its `<ol>` after committed changes, and refreshes through
-the authenticated host request context. Turbo append intents remain roadmap
-work.
+The views demonstrate explicit `broadcast: :value` scalar replacement and a
+default invalidation-only chat-message ERB component. The chat component
+receives `recent_messages` as an ordinary Ruby array, rerenders its `<ol>` after
+committed changes, and refreshes through the authenticated host request
+context. Turbo append intents remain roadmap work.

--- a/examples/application/app/actors/chat_room_actor.rb
+++ b/examples/application/app/actors/chat_room_actor.rb
@@ -6,7 +6,7 @@ class ChatRoomActor < SolidObjects::Actor
   attribute :members, default: -> { [] }
   attribute :recent_messages, default: -> { [] }
 
-  observable :presence do
+  observable :presence, broadcast: :value do
     members.length
   end
 

--- a/examples/application/app/actors/shopping_cart_actor.rb
+++ b/examples/application/app/actors/shopping_cart_actor.rb
@@ -5,11 +5,11 @@ class ShoppingCartActor < SolidObjects::Actor
   attribute :checkout_status, default: "open"
   attribute :payment_id
 
-  observable :items_count do
+  observable :items_count, broadcast: :value do
     items.sum { |item| item.fetch("quantity") }
   end
 
-  observable :subtotal_cents do
+  observable :subtotal_cents, broadcast: :value do
     items.sum do |item|
       item.fetch("quantity") * item.fetch("unit_price_cents")
     end

--- a/lib/solid_objects/actor.rb
+++ b/lib/solid_objects/actor.rb
@@ -53,7 +53,7 @@ module SolidObjects
       end
 
       # @rbs (Symbol | String, ?broadcast: Symbol) ?{ () -> untyped } -> ActorDefinition::Handler
-      def observable(name, broadcast: :value, &block)
+      def observable(name, broadcast: :invalidation, &block)
         definition.add_observable(name, block, broadcast:)
       end
 

--- a/lib/solid_objects/version.rb
+++ b/lib/solid_objects/version.rb
@@ -1,5 +1,5 @@
 # rbs_inline: enabled
 
 module SolidObjects
-  VERSION = "0.12.1"
+  VERSION = "0.13.0"
 end

--- a/test/integration/actor_channel_test.rb
+++ b/test/integration/actor_channel_test.rb
@@ -21,10 +21,10 @@ class ActorChannelTest < ActionCable::Channel::TestCase
     attribute :unrelated, default: 0
     attribute :secret, default: nil
 
-    observable :missing
-    observable :status
-    observable :unrelated
-    observable :secret, broadcast: :invalidation
+    observable :missing, broadcast: :value
+    observable :status, broadcast: :value
+    observable :unrelated, broadcast: :value
+    observable :secret
 
     def update_all
       self.missing += 1
@@ -219,6 +219,19 @@ class ActorChannelTest < ActionCable::Channel::TestCase
     SolidObjects.configuration.authorize_subscription = ->(**) { false }
 
     subscribe token: SolidObjects::StreamToken.generate(reference)
+
+    assert subscription.rejected?
+    assert_no_streams
+  end
+
+  test "rejects default observables as scalar subscriptions" do
+    reference = ChannelActor.ref("actor-1")
+    SolidObjects.configuration.authorize_subscription = ->(**) { true }
+
+    subscribe token: SolidObjects::StreamToken.generate(
+      reference,
+      observables: %w[secret]
+    )
 
     assert subscription.rejected?
     assert_no_streams

--- a/test/integration/actor_helper_test.rb
+++ b/test/integration/actor_helper_test.rb
@@ -15,13 +15,13 @@ class ActorHelperTest < ActionView::TestCase
     attribute :items, default: -> { [] }
     attribute :status, default: "open"
 
-    observable :items_count do
+    observable :items_count, broadcast: :value do
       items.length
     end
 
     observable :items
     observable :status
-    observable :private_status, broadcast: :invalidation do
+    observable :private_status do
       status
     end
 
@@ -91,7 +91,7 @@ class ActorHelperTest < ActionView::TestCase
     assert_equal [ "items_count" ], identity.fetch("observables")
   end
 
-  test "invalidation-only observables do not render as scalar targets" do
+  test "observables default to invalidation-only scalar targets" do
     reference = CartActor.ref("alice")
 
     error = assert_raises(ArgumentError) do

--- a/test/integration/broadcasts_test.rb
+++ b/test/integration/broadcasts_test.rb
@@ -20,12 +20,24 @@ class BroadcastsTest < ActiveSupport::TestCase
     end
   end
 
+  class PublicCounterActor < SolidObjects::Actor
+    actor_type "public-broadcast-counter"
+
+    attribute :count, default: 0
+
+    observable :count, broadcast: :value
+
+    def increment
+      self.count += 1
+    end
+  end
+
   class PrivateRoomActor < SolidObjects::Actor
     actor_type "private-broadcast-room"
 
     attribute :secret, default: nil
 
-    observable :secret, broadcast: :invalidation
+    observable :secret
 
     def reveal(secret:)
       self.secret = secret
@@ -36,7 +48,7 @@ class BroadcastsTest < ActiveSupport::TestCase
     SolidObjects.configuration.retry_delay = ->(_attempt) { 0 }
   end
 
-  test "enqueues changed observables in the state commit" do
+  test "observables default to invalidation-only broadcasts" do
     message_reference = CounterActor.ref("one").async.increment
     worker = SolidObjects::Worker.new
 
@@ -44,11 +56,25 @@ class BroadcastsTest < ActiveSupport::TestCase
 
     broadcast = SolidObjects::Broadcast.find_by!(message_id: message_reference.id)
     assert_equal "count", broadcast.observable_name
-    assert_equal 1, broadcast.value
+    assert_equal({}, broadcast.value)
+    refute broadcast.broadcasts_value?
     assert_equal "pending", broadcast.status
     assert_equal 1, broadcast.state_version
     assert_equal 1, broadcast.activation_generation
     assert_equal message_reference.sequence, broadcast.instance.state_revision
+  ensure
+    worker&.stop
+  end
+
+  test "value broadcasts require an explicit opt-in" do
+    message_reference = PublicCounterActor.ref("one").async.increment
+    worker = SolidObjects::Worker.new
+
+    worker.run_until_idle
+
+    broadcast = SolidObjects::Broadcast.find_by!(message_id: message_reference.id)
+    assert_equal 1, broadcast.value
+    assert broadcast.broadcasts_value?
   ensure
     worker&.stop
   end
@@ -85,7 +111,7 @@ class BroadcastsTest < ActiveSupport::TestCase
   test "delivers the durable broadcast after commit" do
     delivered = Queue.new
     SolidObjects.configuration.broadcast_adapter = ->(broadcast) { delivered << broadcast.value }
-    CounterActor.ref("one").async.increment
+    PublicCounterActor.ref("one").async.increment
     worker = SolidObjects::Worker.new
     worker.run_until_idle
     broadcast_executor = SolidObjects::BroadcastExecutor.new

--- a/test/unit/actor_test.rb
+++ b/test/unit/actor_test.rb
@@ -133,6 +133,18 @@ class ActorTest < ActiveSupport::TestCase
     assert_equal({ "count" => 3 }, actor.observable_values)
   end
 
+  test "observables default to invalidation-only" do
+    refute CartActor.definition.broadcasts_observable_value?(:count)
+  end
+
+  test "observables explicitly opt into value broadcasts" do
+    actor_class = Class.new(SolidObjects::Actor) do
+      observable :value, broadcast: :value
+    end
+
+    assert actor_class.definition.broadcasts_observable_value?(:value)
+  end
+
   test "rejects unknown observable broadcast modes" do
     error = assert_raises(SolidObjects::InvalidActor) do
       Class.new(SolidObjects::Actor) do


### PR DESCRIPTION
## Summary

- make ordinary observables invalidation-only by default
- require `broadcast: :value` before a projection may be persisted or sent as a scalar Turbo replacement
- keep default observables available to authorized component rendering and change detection
- bump the gem to 0.13.0 and update the README, realtime/security guidance, examples, architecture, schema documentation, ADR, roadmap, changelog, and lockfile

```ruby
observable :recent_messages
observable :message_count, broadcast: :value
```

## Security and compatibility

This is a breaking default change. An unqualified observable that rendered as a scalar in 0.12.x must add `broadcast: :value`. Forgetting the opt-in now produces a visible scalar-rendering error instead of silently persisting and sharing the value with every authorized actor subscriber.

No database migration is required. The 0.12.1 runtime already supports both broadcast modes, stores `{}` for invalidation-only rows, suppresses their scalar Turbo frames, and refreshes dependent components from committed state.

v0.12.1 is already published and did not include a deprecation warning for implicit value broadcasts. This 0.13.0 branch cannot add that warning retroactively, and warning after the safe default takes effect would penalize the intended API. If a warning period is required, publish a separate 0.12.2 maintenance release before merging and tagging this PR.

## Test-first evidence

Before changing the default:

```text
ActorTest#test_observables_default_to_invalidation-only
Expected true to not be truthy.
```

After implementation:

- `bundle exec ruby -Itest test/unit/actor_test.rb`
- `bundle exec ruby -Itest test/integration/broadcasts_test.rb`
- `bundle exec ruby -Itest test/integration/actor_helper_test.rb`
- `bundle exec ruby -Itest test/integration/actor_channel_test.rb`
- `bundle exec rake test` — 439 runs, 1,472 assertions, 0 failures, 0 errors, 14 environment-gated adapter skips before the final subscription-boundary assertion
- `bundle exec rake rbs`
- `bundle exec rake` — 440 runs, 1,474 assertions, 0 failures, 0 errors, 14 environment-gated adapter skips; Standard Ruby, RuboCop, RBS generation and validation, Steep, and Brakeman all passed; 0 security warnings

The skipped tests are PostgreSQL/MySQL version and reconciliation checks, PostgreSQL/Redis wake-up adapters, and database-specific lock cases. Observable persistence and rendering coverage was not skipped.
