### PR TITLE
feat: add operator dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased
+
+- Add `SolidObjects::Web`, a mountable Rack dashboard for the actor runtime.
+  It covers instances and their committed state, the ready and claimed
+  mailbox, reminders, effects, broadcasts, dead letters, and processes, with
+  actor-type and actor-id filtering, status filters, paging, and a polled
+  `GET /stats` endpoint. Mount it with
+  `mount SolidObjects::Web => "/solid_objects/dashboard"` after
+  `require "solid_objects/web"`; requiring the gem does not load it, so a
+  worker process carries no web stack.
+- Authorize every dashboard route through `authorize_administration`. Each
+  route declares its own `action` and `resource`, and a route declared without
+  a policy raises at load time. The policy receives a context that answers
+  `request`, `session`, and `env`.
+- Add two dashboard actions: an idempotent dead letter retry through
+  `SolidObjects.dead_letters.retry`, and instance pause/resume, which sets and
+  clears `paused_at` so the activation manager stops claiming that identity. A
+  retry the mailbox refuses, such as an actor class that no longer exists,
+  renders the reason with a 422 rather than failing the request.
+- Draw instances per actor type, mailbox depth, and outbox and reminder status
+  with Chart.js, loaded from a CDN with a subresource integrity hash. The CDN
+  host is the only external origin the content security policy names. Point
+  `SolidObjects::Web.chart_library_url` at a vendored copy for a deployment
+  with no outbound network access, or set it to nil to render without charts.
+- Add `SolidObjects::Web.register` for extension tabs, routes, and view
+  directories, and `SolidObjects::Web.use` for Rack middleware in front of the
+  dashboard.
+- Add `rack` as an explicit dependency at `>= 3.1`, and package the `web/`
+  directory in the gem.
+
 ## 0.13.0 - 2026-08-13
 
 - **Breaking:** make observables invalidation-only by default. An ordinary

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       actionview (>= 8.0)
       activerecord (>= 8.0)
       activesupport (>= 8.0)
+      rack (>= 3.1)
       railties (>= 8.0)
       thor (>= 1.3)
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ tested, but the project does not yet claim production readiness. See
 - [State migrations](#state-migrations)
 - [Configuration](#configuration)
 - [Workers and operations](#workers-and-operations)
+- [Dashboard](#dashboard)
 - [Database support](#database-support)
 - [Guarantees](#guarantees)
 - [When to use it](#when-to-use-it)
@@ -1083,6 +1084,50 @@ an initializer.
 
 See the [operations guide](docs/operations.md) for monitoring, reconciliation,
 shutdown, retention, and backup guidance.
+
+## Dashboard
+
+`SolidObjects::Web` is a Rack application that shows instances and their state,
+the mailbox, reminders, effects, broadcasts, dead letters, and the registered
+processes. Mount it inside the application routes, so the Rails session
+middleware runs first:
+
+```ruby
+# config/routes.rb
+require "solid_objects/web"
+
+Rails.application.routes.draw do
+  mount SolidObjects::Web => "/solid_objects/dashboard"
+end
+```
+
+It is not loaded by `require "solid_objects"`: a worker process must not carry
+a web stack. The dashboard and the engine are separate mounts, so an
+application that uses reactive ERB mounts both on different paths.
+
+Every page asks `authorize_administration` before its handler runs, and that
+policy denies by default, so a mount alone exposes nothing. The block receives
+the route's own `action:` and `resource:`, and an `authorization_context:` that
+answers `request`, `session`, and `env`.
+
+The dashboard changes only two things. Retrying a dead letter goes through
+`SolidObjects.dead_letters.retry`, which is idempotent. Pausing an instance
+sets `paused_at` so the activation manager stops claiming that identity; a pass
+already in flight finishes its turn, and a synchronous caller waiting on a
+paused instance times out rather than receiving a result.
+
+The dashboard draws instances per actor type, mailbox depth, and outbox status
+with Chart.js, loaded from a CDN with a subresource integrity hash. A
+deployment with no outbound network access can vendor the file, or turn the
+charts off:
+
+```ruby
+SolidObjects::Web.chart_library_url = "/javascripts/chart.umd.min.js"
+SolidObjects::Web.chart_library_integrity = nil
+```
+
+Read the [dashboard guide](docs/dashboard.md) for the full policy table,
+extension registration, and query cost.
 
 ## Database support
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -13,7 +13,7 @@ intentionally inert until the host application defines its trust boundary.
 | `authorize_query` | Attribute reads, declared queries, committed snapshots, scalar observable reads, initial component rendering, and every component refresh dependency | Explicit call context, the context passed to `solid_object`, or the request context resolved for a component refresh | Actor state or personalized projections can leak across users or tenants |
 | `authorize_destroy` | `reference.destroy` | Value passed as `authorization_context:` | Complete actor state, mailbox, reminders, and pending outboxes can be deleted |
 | `authorize_subscription` | Action Cable subscription to one actor stream | The `ActionCable::Connection` object | Clients can receive future observable updates for other actors |
-| `authorize_administration` | Engine administration controllers, process inspection/cleanup/pruning, message pruning, and dead-letter inspection/retry | Rails controller or `{ source: "cli" }` | Operational metadata, arguments, errors, deletion, and retries become exposed or mutable |
+| `authorize_administration` | Engine administration controllers, every `SolidObjects::Web` page, process inspection/cleanup/pruning, message pruning, and dead-letter inspection/retry | Rails controller, a `SolidObjects::Web` request that answers `request`/`session`/`env`, or `{ source: "cli" }` | Operational metadata, arguments, errors, deletion, and retries become exposed or mutable |
 
 Waiting again through `MessageReference#wait` reauthorizes the stored
 invocation as a message or query. Internal reminder, effect-callback, and
@@ -153,6 +153,13 @@ configuration.authorize_administration = lambda do |authorization_context:, **|
     authorization_context[:source] == "cli"
 end
 ```
+
+That policy also denies every `SolidObjects::Web` page, which is the correct
+result for a host whose only administration boundary is shell access. A policy
+that opens the dashboard should separate reading from writing, because
+`action` distinguishes them: `index` and `show` read, while `pause`, `resume`,
+and `retry` change the runtime. The [dashboard guide](dashboard.md) lists the
+action and resource of every page.
 
 Run `bin/rails solid_objects:doctor` after configuration. Its neutral policy
 probe is deliberately conservative: a context-aware policy may correctly warn

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,200 @@
+# Operator dashboard
+
+`SolidObjects::Web` is a Rack application that shows what the actor runtime is
+doing: instances and their state, the mailbox, reminders, effects, broadcasts,
+dead letters, and the registered processes. It reads the same tables the
+runtime writes, so it needs no separate store and no agent.
+
+It is deliberately not loaded by `require "solid_objects"`. A worker process
+must not carry a web stack, and an application that never mounts the dashboard
+must not pay for it.
+
+## Mounting
+
+```ruby
+# config/routes.rb
+require "solid_objects/web"
+
+Rails.application.routes.draw do
+  mount SolidObjects::Web => "/solid_objects/dashboard"
+end
+```
+
+Mount it inside the application routes so the Rails session middleware runs
+first. The dashboard needs a Rack session for CSRF protection and refuses a
+state changing request without one.
+
+The dashboard and the engine are separate mounts. Mount the engine as well if
+the application uses reactive ERB, and give each one its own path:
+
+```ruby
+mount SolidObjects::Engine => "/solid_objects"
+mount SolidObjects::Web => "/solid_objects/dashboard"
+```
+
+In a bare Rack application, supply the session middleware yourself:
+
+```ruby
+use Rack::Session::Cookie, secret: ENV.fetch("SESSION_SECRET"), same_site: true
+run SolidObjects::Web
+```
+
+## Authorization
+
+Every page asks `configuration.authorize_administration` before its handler
+runs. That policy denies by default, so a mount alone exposes nothing. A route
+declared without a policy raises at load time, which is why a new page cannot
+reach the actor tables before an application has said who may read it.
+
+The block receives the route's own action and resource:
+
+| Page | `action` | `resource` | `resource_id` |
+| --- | --- | --- | --- |
+| Dashboard, `GET /stats`, `HEAD /` | `index` | `dashboard` | none |
+| Instance list | `index` | `instances` | none |
+| Instance detail | `show` | `instances` | instance id |
+| Pause an instance | `pause` | `instances` | instance id |
+| Resume an instance | `resume` | `instances` | instance id |
+| Mailbox | `index` | `messages` | none |
+| Message detail | `show` | `messages` | message id |
+| Reminders | `index` | `reminders` | none |
+| Effects | `index` | `effects` | none |
+| Broadcasts | `index` | `broadcasts` | none |
+| Dead letter list | `index` | `dead_letters` | none |
+| Dead letter detail | `show` | `dead_letters` | dead letter id |
+| Retry a dead letter | `retry` | `dead_letters` | dead letter id |
+| Processes | `index` | `processes` | none |
+
+`authorization_context:` is the request object. It answers `request`,
+`session`, and `env`, so a policy can read the signed-in operator the same way
+a controller does:
+
+```ruby
+SolidObjects.configure do |configuration|
+  configuration.authorize_administration = lambda do |action:, authorization_context:, **|
+    return false unless authorization_context.respond_to?(:session)
+
+    operator = Operator.find_by(id: authorization_context.session[:operator_id])
+    return false unless operator&.administrator?
+
+    action == "index" || action == "show" || operator.may_write_runtime?
+  end
+end
+```
+
+The command line reaches the same policy with `{ source: "cli" }` rather than
+a request, which is why the example checks what the context answers before
+reading a session from it.
+
+## Pages
+
+**Dashboard.** Totals per subsystem, the registered processes, and the most
+recent dead letters. The summary bar appears on every page and can poll
+`GET /stats` for the same numbers; nothing else on the page refreshes, because
+a table that reloads under an operator who is reading it is worse than a stale
+one.
+
+**Instances.** Filter by actor type and by an actor id substring. Each row
+shows the lease state: `idle`, `activated`, `expired`, or `paused`. The detail
+page shows committed state, the ready and claimed mailbox, message history,
+reminders, effects, broadcasts, and dead letters for that identity.
+
+**Mailbox.** The ready and claimed messages across every identity, oldest
+first. Mailbox lag on the summary bar is the age of the oldest message that is
+already due, which is how far behind the workers are.
+
+**Reminders, effects, broadcasts, processes.** Status filtered lists.
+
+## Charts
+
+The dashboard draws three charts: instances per actor type, mailbox depth, and
+a stacked view of effects, broadcasts, and reminders by status. Each canvas
+carries its own numbers in a `data-chart-values` attribute, so the page needs
+no inline script and no request to draw. Mailbox depth and the status chart
+redraw when the Live poller reports new totals, because `/stats` already
+carries those numbers. The instance chart does not: `/stats` does not group by
+actor type, and adding that would put a `GROUP BY` on every poll.
+
+Chart.js comes from a CDN with a subresource integrity hash, so a compromised
+CDN cannot substitute other code, and the CDN host is the only external origin
+the content security policy names.
+
+A deployment with no outbound network access should vendor the file:
+
+```ruby
+SolidObjects::Web.chart_library_url = "/javascripts/chart.umd.min.js"
+SolidObjects::Web.chart_library_integrity = nil
+```
+
+A path below the mount is served from the dashboard's own asset directory and
+needs no policy exception. Setting the URL to `nil` renders the dashboard
+without charts and names no external origin at all.
+
+Set these before the first request. The middleware stack and the compiled
+templates are built once and cached.
+
+**Dead letters.** The exception, its message, and its backtrace, with a retry
+button.
+
+## Actions
+
+The dashboard changes only two things.
+
+**Retry a dead letter** goes through `SolidObjects.dead_letters.retry`, which
+enqueues the original operation under an idempotency key. Pressing it twice
+produces one message rather than two.
+
+A retry re-enters the mailbox, which refuses work the runtime cannot accept: an
+actor class that no longer exists, a full mailbox, a payload over the cap. The
+dashboard renders the dead letter again with the reason and a 422 status,
+rather than failing the request.
+
+**Pause an instance** sets `paused_at`, and the activation manager stops
+claiming that identity. Two consequences matter:
+
+- A pass already in flight finishes its turn. Pause is not a stop.
+- A synchronous caller waiting on a paused instance times out rather than
+  receiving a result, because nothing will execute its message.
+
+Resume clears the column and the mailbox drains in sequence order.
+
+## Extensions
+
+An extension adds pages by declaring routes on the application class. Its
+routes carry an authorization policy like every other route:
+
+```ruby
+module Tenants
+  def self.registered(application)
+    application.get "/tenants", policy: { action: "index", resource: "tenants" } do
+      @tenants = Tenant.order(:name)
+      erb(:tenants)
+    end
+  end
+end
+
+SolidObjects::Web.register(
+  Tenants,
+  tab: "Tenants",
+  path: "/tenants",
+  views: File.expand_path("../web/views", __dir__)
+)
+```
+
+A registered view directory is searched before the packaged one, so an
+application can replace a single page without forking the gem. A template
+reads its arguments from `locals`, and a replacement `layout.erb` renders the
+page it wraps with `locals.fetch(:content)`.
+
+Add Rack middleware in front of the dashboard with `SolidObjects::Web.use`,
+for example to require HTTP basic authentication in an environment that has no
+session-backed operator.
+
+## Cost
+
+The summary bar issues one grouped count per subsystem on every page, and each
+list page counts its own relation to page it. That is a fixed set of indexed
+aggregate queries, not a scan proportional to actor traffic, but it is not
+free: do not put the dashboard behind an uptime monitor that loads the whole
+page on an interval. `HEAD /` exists for that. It touches one table and
+returns no body.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -108,8 +108,25 @@
   handing the block a raw Cable connection.
 - Backpressure: mailbox/payload/state/result caps and fair yields exist;
   distributed per-actor rate limits and global admission control do not.
-- Administration: actor and dead-letter views plus policy hooks exist; richer
-  filtering, audit records, and bulk-safe tools do not.
+- Administration: `SolidObjects::Web` is a mountable Rack dashboard covering
+  instances, mailbox, reminders, effects, broadcasts, dead letters, and
+  processes, with actor-type and actor-id filtering, status filters, paging, a
+  polled stats endpoint, Chart.js charts, and extension registration. The chart
+  library is fetched from a CDN with a subresource integrity hash, which a
+  deployment without outbound network access must replace with a vendored copy
+  or turn off. Every route declares its
+  own administration policy and a route declared without one raises at load
+  time, so the deny-by-default posture is enforced by construction rather than
+  by remembering to add a check. It changes only two things: an idempotent dead
+  letter retry and instance pause/resume. What does not exist is audit records
+  of who pressed what, and bulk-safe tools: retry is one dead letter at a time,
+  because `DeadLetterManager` exposes no bulk operation. Pause is an operator
+  brake and not a stop, since a pass already in flight finishes its turn and a
+  synchronous caller waiting on a paused instance times out. The page cost was
+  reasoned about rather than measured: the summary bar issues a fixed set of
+  indexed aggregate queries per page, which is why `HEAD /` exists for uptime
+  monitors, but no dashboard latency has been benchmarked against a large
+  table.
 
 ## Next milestones
 

--- a/lib/solid_objects/web.rb
+++ b/lib/solid_objects/web.rb
@@ -1,0 +1,222 @@
+# rbs_inline: enabled
+
+require "erb"
+require "json"
+require "securerandom"
+require "uri"
+require "rack"
+require "rack/builder"
+require "rack/static"
+
+require "solid_objects"
+require "solid_objects/web/route"
+require "solid_objects/web/router"
+require "solid_objects/web/statistics"
+require "solid_objects/web/paginator"
+require "solid_objects/web/helpers"
+require "solid_objects/web/action"
+require "solid_objects/web/csrf_protection"
+require "solid_objects/web/application"
+
+module SolidObjects
+  # An operator dashboard for the actor runtime, served as a Rack application:
+  #
+  #   Rails.application.routes.draw do
+  #     mount SolidObjects::Web => "/solid_objects"
+  #   end
+  #
+  # It is deliberately not loaded by `require "solid_objects"`. A worker
+  # process must not carry a web stack, and an application that never mounts
+  # the dashboard must not pay for it.
+  #
+  # Every page asks `configuration.authorize_administration` first. That block
+  # denies by default, so a mount alone exposes nothing until an application
+  # states who may read it.
+  class Web
+    ROOT = File.expand_path("../../web", __dir__)
+    VIEWS = File.join(ROOT, "views")
+    ASSETS = File.join(ROOT, "assets")
+
+    NONCE_KEY = "solid_objects.content_security_policy_nonce"
+    CSRF_TOKEN_KEY = "solid_objects.csrf_token"
+    NONCE_BYTES = 16
+    ASSET_CACHE_SECONDS = 86_400
+    TEMPLATE_NAME = /\A_?[a-z][a-z0-9_]*\z/
+
+    # The dashboard charts need a charting library, and this one is fetched
+    # from a public CDN with a subresource integrity hash, so a compromised CDN
+    # cannot substitute other code. A deployment with no outbound network
+    # access should vendor the file and point `chart_library_url` at it, or set
+    # that to nil to render the dashboard without charts.
+    CHART_LIBRARY_URL = "https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js"
+    CHART_LIBRARY_INTEGRITY = "sha384-XcdcwHqIPULERb2yDEM4R0XaQKU3YnDsrTmjACBZyfdVVqjh6xQ4/DCMd7XLcA6Y"
+
+    DEFAULT_TABS = {
+      "Dashboard" => "/",
+      "Instances" => "/instances",
+      "Mailbox" => "/mailbox",
+      "Reminders" => "/reminders",
+      "Effects" => "/effects",
+      "Broadcasts" => "/broadcasts",
+      "Dead letters" => "/dead_letters",
+      "Processes" => "/processes"
+    }.freeze
+
+    LOCK = Mutex.new
+
+    class << self
+      # A path below the mount serves a vendored copy; an absolute URL is
+      # fetched from that host and is named in the content security policy.
+      # nil renders the dashboard without charts.
+      # @rbs @chart_library_url: String?
+      # @rbs @chart_library_integrity: String?
+      attr_writer :chart_library_url, :chart_library_integrity
+
+      # @rbs () -> String?
+      def chart_library_url
+        defined?(@chart_library_url) ? @chart_library_url : CHART_LIBRARY_URL
+      end
+
+      # @rbs () -> String?
+      def chart_library_integrity
+        defined?(@chart_library_integrity) ? @chart_library_integrity : CHART_LIBRARY_INTEGRITY
+      end
+
+      # @rbs () -> bool
+      def charts?
+        !chart_library_url.nil?
+      end
+
+      # The origin the content security policy has to allow. A vendored copy
+      # served from the mount has none, so the policy stays at 'self'.
+      # @rbs () -> String?
+      def chart_library_origin
+        url = chart_library_url
+        return nil unless url&.include?("//")
+
+        uri = URI.parse(url)
+        return nil unless uri.scheme && uri.host
+
+        "#{uri.scheme}://#{uri.host}"
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      # @rbs () -> Hash[String, String]
+      def tabs
+        @tabs ||= DEFAULT_TABS.dup
+      end
+
+      # Searched in order, so an extension directory added first wins over the
+      # packaged one and an application can replace a single page.
+      # @rbs () -> Array[String]
+      def views
+        @views ||= [ VIEWS ]
+      end
+
+      # @rbs () -> Array[[Array[untyped], Proc?]]
+      def middlewares
+        @middlewares ||= []
+      end
+
+      # The built stack is memoized, so a middleware added after the first
+      # request would otherwise be dropped without a word.
+      # @rbs (*untyped) ?{ () -> untyped } -> void
+      def use(*arguments, &block)
+        middlewares << [ arguments, block ]
+        LOCK.synchronize { @application = nil }
+      end
+
+      # Adds pages to the dashboard. The extension receives the application
+      # class and declares its own routes on it, which means its routes carry
+      # an authorization policy like every other route.
+      #
+      # @rbs (untyped, tab: String, path: String, ?views: String?) -> void
+      def register(extension, tab:, path:, views: nil)
+        if views
+          self.views.unshift(views)
+          # A template compiled before this call resolved against the old
+          # search path, so a replacement view would never be reached.
+          LOCK.synchronize { @templates = {} }
+        end
+        tabs[tab] = path
+        extension.registered(Application)
+      end
+
+      # @rbs (Symbol) -> untyped
+      def template(name)
+        LOCK.synchronize do
+          templates[name] ||= ERB.new(File.read(template_path(name)), trim_mode: "-")
+        end
+      end
+
+      # @rbs () -> void
+      def reset!
+        LOCK.synchronize { @templates = {} }
+        @tabs = nil
+        @views = nil
+        @middlewares = nil
+        @application = nil
+        remove_instance_variable(:@chart_library_url) if defined?(@chart_library_url)
+        remove_instance_variable(:@chart_library_integrity) if defined?(@chart_library_integrity)
+      end
+
+      # @rbs (Hash[String, untyped]) -> Array[untyped]
+      def call(env)
+        application.call(env)
+      end
+
+      # @rbs () -> Web
+      def application
+        LOCK.synchronize { @application ||= new }
+      end
+
+      private
+
+      # @rbs () -> Hash[Symbol, untyped]
+      def templates
+        @templates ||= {}
+      end
+
+      # A template name never comes from a request, and this keeps it that way
+      # rather than trusting every future caller to know it.
+      # @rbs (Symbol) -> String
+      def template_path(name)
+        raise ArgumentError, "invalid template name" unless name.to_s.match?(TEMPLATE_NAME)
+
+        found = views.lazy.map { |directory| File.join(directory, "#{name}.erb") }.find { |path| File.exist?(path) }
+        found || raise(ArgumentError, "no template named #{name}")
+      end
+    end
+
+    # @rbs (Hash[String, untyped]) -> Array[untyped]
+    def call(env)
+      env[NONCE_KEY] = SecureRandom.base64(NONCE_BYTES)
+      app.call(env)
+    end
+
+    # @rbs () -> untyped
+    def app
+      @app ||= build
+    end
+
+    private
+
+    # @rbs () -> untyped
+    def build
+      assets = ASSETS
+      extra = self.class.middlewares
+
+      ::Rack::Builder.new do
+        use ::Rack::Static,
+          urls: [ "/stylesheets", "/javascripts" ],
+          root: assets,
+          cascade: true,
+          header_rules: [ [ :all, { "cache-control" => "private, max-age=#{ASSET_CACHE_SECONDS}" } ] ]
+        extra.each { |arguments, block| use(*arguments, &block) }
+        use CsrfProtection
+        run Application.new
+      end
+    end
+  end
+end

--- a/lib/solid_objects/web/action.rb
+++ b/lib/solid_objects/web/action.rb
@@ -1,0 +1,109 @@
+# rbs_inline: enabled
+
+require "erb"
+require "rack/request"
+require "rack/utils"
+
+module SolidObjects
+  class Web
+    # One request. A route handler runs inside an instance of this class, so a
+    # handler and the template it renders share the same helpers and the same
+    # request.
+    class Action
+      include Helpers
+
+      # @rbs @env: Hash[String, untyped]
+      # @rbs @route: Route
+      # @rbs @captures: Hash[Symbol, String?]
+      # @rbs @request: untyped
+      # @rbs @layout_rendered: bool
+      # @rbs @response_status: Integer
+
+      attr_reader :env, :route, :response_status
+
+      # @rbs (env: Hash[String, untyped], route: Route) -> void
+      def initialize(env:, route:)
+        @env = env
+        @route = route
+        @captures = route.capture(env["PATH_INFO"].to_s)
+        @layout_rendered = false
+        @response_status = 200
+      end
+
+      # Sets the status a rendered page is served with. `halt` and `redirect`
+      # stop the handler, so a page that must render its own body and still
+      # report a failure needs this instead.
+      # @rbs (Integer) -> void
+      def status(code)
+        @response_status = code
+      end
+
+      # @rbs () -> untyped
+      def request
+        @request ||= ::Rack::Request.new(env)
+      end
+
+      # @rbs () -> Hash[untyped, untyped]?
+      def session
+        env["rack.session"]
+      end
+
+      # @rbs (Symbol) -> String?
+      def route_params(key)
+        @captures[key]
+      end
+
+      # @rbs (String) -> untyped
+      def url_params(key)
+        request.params[key]
+      end
+
+      # @rbs () -> untyped
+      def call
+        instance_exec(&route.handler)
+      end
+
+      # The layout is rendered once per request. The flag is raised before the
+      # page body runs so a partial the body renders returns its own fragment
+      # rather than a second whole page. The layout reads the page it wraps
+      # from `locals.fetch(:content)`.
+      # @rbs (Symbol, ?Hash[Symbol, untyped]) -> String
+      def erb(name, locals = {})
+        return evaluate(Web.template(name), locals) if @layout_rendered
+
+        @layout_rendered = true
+        content = evaluate(Web.template(name), locals)
+        evaluate(Web.template(:layout), { content: })
+      end
+
+      # @rbs (Integer, ?String) -> void
+      def halt(status, body = ::Rack::Utils::HTTP_STATUS_CODES.fetch(status, "Error"))
+        throw :halt, [ status, { "content-type" => "text/plain" }, [ body ] ]
+      end
+
+      # @rbs (String) -> void
+      def redirect(path)
+        throw :halt, [ 302, { "location" => path_to(path) }, [] ]
+      end
+
+      # @rbs (untyped) -> void
+      def json(payload)
+        throw :halt, [
+          200,
+          { "content-type" => "application/json", "cache-control" => "private, no-store" },
+          [ JSON.generate(payload) ]
+        ]
+      end
+
+      private
+
+      # `locals` is a local variable of this method, so a template reads it by
+      # name, and every helper is reachable because the template runs against
+      # this object.
+      # @rbs (untyped, Hash[Symbol, untyped]) -> String
+      def evaluate(template, locals)
+        template.result(binding)
+      end
+    end
+  end
+end

--- a/lib/solid_objects/web/application.rb
+++ b/lib/solid_objects/web/application.rb
@@ -1,0 +1,239 @@
+# rbs_inline: enabled
+
+module SolidObjects
+  class Web
+    # The pages. Each route states the administration policy it needs, and
+    # `call` asks that policy before the handler runs, so a page cannot read
+    # the actor tables on behalf of an unauthorized request.
+    class Application
+      extend Router
+
+      SCRIPT_PLACEHOLDER = "!script-src!"
+      CONTENT_SECURITY_POLICY = [
+        "default-src 'self'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "frame-ancestors 'none'",
+        "img-src 'self' data:",
+        "style-src 'self'",
+        "script-src #{SCRIPT_PLACEHOLDER}",
+        "connect-src 'self'",
+        "object-src 'none'"
+      ].join("; ").freeze
+
+      MAILBOX_MEMBERSHIPS = %w[ready claimed].freeze
+      RECENT_LIMIT = 10
+      CHART_TYPE_LIMIT = 12
+
+      head "/", policy: { action: "index", resource: "dashboard" } do
+        # The cheapest liveness check available: it proves the dashboard can
+        # reach the database the actors run on, and returns no body.
+        ReadyMessage.count
+        ""
+      end
+
+      get "/", policy: { action: "index", resource: "dashboard" } do
+        @statistics = statistics.to_h
+        @processes = Process.order(last_heartbeat_at: :desc).limit(RECENT_LIMIT)
+        @dead_letters = DeadLetter.order(last_failed_at: :desc, id: :desc).limit(RECENT_LIMIT)
+        # The only chart that costs its own query, and the only one the poller
+        # cannot refresh, because the other two read what `/stats` already
+        # returns. Bounded so a runtime with many actor types draws a readable
+        # chart rather than every type it has ever seen.
+        @instances_by_type = Instance
+          .group(:actor_type)
+          .order(Arel.sql("COUNT(*) DESC"))
+          .limit(CHART_TYPE_LIMIT)
+          .count
+        erb(:dashboard)
+      end
+
+      get "/stats", policy: { action: "index", resource: "dashboard" } do
+        json(statistics.to_h)
+      end
+
+      get "/instances", policy: { action: "index", resource: "instances" } do
+        @paginator = paginate(filtered_instances)
+        # Suggestions come from the registry rather than a DISTINCT over the
+        # instances table, which no adapter can answer from an index. The field
+        # stays free text, so an actor type that is no longer registered is
+        # still reachable.
+        @actor_types = SolidObjects.registry.to_h.keys.sort
+        erb(:instances)
+      end
+
+      get "/instances/:id", policy: { action: "show", resource: "instances" } do
+        @instance = find_instance
+        @ready_messages = @instance.messages
+          .where(id: ReadyMessage.select(:message_id))
+          .order(sequence: :asc)
+          .limit(RECENT_LIMIT)
+        @claimed_messages = @instance.messages
+          .where(id: ClaimedMessage.select(:message_id))
+          .order(sequence: :asc)
+          .limit(RECENT_LIMIT)
+        @recent_messages = @instance.messages.order(sequence: :desc).limit(RECENT_LIMIT)
+        @reminders = Reminder.where(instance_id: @instance.id).order(next_run_at: :asc).limit(RECENT_LIMIT)
+        @effects = Effect.where(instance_id: @instance.id).order(id: :desc).limit(RECENT_LIMIT)
+        @broadcasts = Broadcast.where(instance_id: @instance.id).order(id: :desc).limit(RECENT_LIMIT)
+        @dead_letters = DeadLetter.where(instance_id: @instance.id).order(last_failed_at: :desc).limit(RECENT_LIMIT)
+        erb(:instance)
+      end
+
+      # Pausing stops the activation manager from claiming the instance again.
+      # A pass already in flight finishes its turn, and a synchronous caller
+      # waiting on this instance times out rather than being answered, so this
+      # is an operator brake and not a delivery guarantee.
+      post "/instances/:id/pause", policy: { action: "pause", resource: "instances" } do
+        instance = find_instance
+        instance.update!(paused_at: SolidObjects.database_adapter.database_now)
+        redirect("/instances/#{instance.id}")
+      end
+
+      post "/instances/:id/resume", policy: { action: "resume", resource: "instances" } do
+        instance = find_instance
+        instance.update!(paused_at: nil)
+        redirect("/instances/#{instance.id}")
+      end
+
+      get "/mailbox", policy: { action: "index", resource: "messages" } do
+        @membership = filter_value(MAILBOX_MEMBERSHIPS, default: "ready")
+        @paginator = paginate(mailbox_messages(@membership))
+        erb(:mailbox)
+      end
+
+      get "/messages/:id", policy: { action: "show", resource: "messages" } do
+        @message = Message.find_by(id: route_params(:id))
+        halt(404) unless @message
+        erb(:message)
+      end
+
+      get "/reminders", policy: { action: "index", resource: "reminders" } do
+        @status = filter_value(Statistics::REMINDER_STATUSES)
+        relation = Reminder.order(next_run_at: :asc, id: :asc)
+        @paginator = paginate(@status ? relation.where(status: @status) : relation)
+        erb(:reminders)
+      end
+
+      get "/effects", policy: { action: "index", resource: "effects" } do
+        @status = filter_value(Statistics::EFFECT_STATUSES)
+        relation = Effect.order(id: :desc)
+        @paginator = paginate(@status ? relation.where(status: @status) : relation)
+        erb(:effects)
+      end
+
+      get "/broadcasts", policy: { action: "index", resource: "broadcasts" } do
+        @status = filter_value(Statistics::BROADCAST_STATUSES)
+        relation = Broadcast.order(id: :desc)
+        @paginator = paginate(@status ? relation.where(status: @status) : relation)
+        erb(:broadcasts)
+      end
+
+      get "/dead_letters", policy: { action: "index", resource: "dead_letters" } do
+        @paginator = paginate(DeadLetter.order(last_failed_at: :desc, id: :desc))
+        erb(:dead_letters)
+      end
+
+      get "/dead_letters/:id", policy: { action: "show", resource: "dead_letters" } do
+        @dead_letter = DeadLetter.find_by(id: route_params(:id))
+        halt(404) unless @dead_letter
+        erb(:dead_letter)
+      end
+
+      # A retry re-enters the mailbox, which refuses work the runtime cannot
+      # accept: an actor class that no longer exists, a full mailbox, a payload
+      # over the cap. The operator who pressed the button is told which,
+      # instead of being handed a bare 500 from the Rack handler.
+      post "/dead_letters/:id/retry", policy: { action: "retry", resource: "dead_letters" } do
+        SolidObjects.dead_letters.retry(route_params(:id).to_i, authorization_context: self)
+        redirect("/dead_letters")
+      rescue Unauthorized
+        raise
+      rescue SolidObjects::Error => error
+        @dead_letter = DeadLetter.find_by(id: route_params(:id))
+        halt(404) unless @dead_letter
+        @error = "#{error.class.name.split("::").last}: #{error.message}"
+        status(422)
+        erb(:dead_letter)
+      end
+
+      get "/processes", policy: { action: "index", resource: "processes" } do
+        @status = filter_value(Statistics::PROCESS_STATES)
+        relation = Process.order(last_heartbeat_at: :desc)
+        @paginator = paginate(@status ? relation.where(shutdown_state: @status) : relation)
+        # Counted in one grouped query rather than once per row, because this
+        # page is read while the runtime is already under load.
+        @activated_counts = Instance
+          .where(activation_owner_id: @paginator.records.map(&:id))
+          .group(:activation_owner_id)
+          .count
+        erb(:processes)
+      end
+
+      # @rbs (Hash[String, untyped]) -> Array[untyped]
+      def call(env)
+        route = self.class.match(env["REQUEST_METHOD"].to_s, env["PATH_INFO"].to_s)
+        return not_found unless route
+
+        action = Action.new(env:, route:)
+        return forbidden unless authorized?(action)
+
+        respond(action, catch(:halt) { action.call })
+      rescue Unauthorized
+        forbidden
+      end
+
+      private
+
+      # @rbs (Action, untyped) -> Array[untyped]
+      def respond(action, result)
+        return result if result.is_a?(Array)
+
+        [ action.response_status, page_headers(action.env), [ result.to_s ] ]
+      end
+
+      # @rbs (Action) -> bool
+      def authorized?(action)
+        policy = action.route.policy
+        SolidObjects.configuration.authorize_administration.call(
+          action: policy.fetch(:action),
+          resource: policy.fetch(:resource),
+          resource_id: action.route_params(:id),
+          authorization_context: action
+        )
+      end
+
+      # @rbs (Hash[String, untyped]) -> Hash[String, String]
+      def page_headers(env)
+        {
+          "content-type" => "text/html; charset=utf-8",
+          "cache-control" => "private, no-store",
+          "content-security-policy" => content_security_policy(env),
+          "x-content-type-options" => "nosniff",
+          "referrer-policy" => "same-origin"
+        }
+      end
+
+      # The chart host is named only when one is configured, so a deployment
+      # that vendors the library or turns charts off never advertises a third
+      # party origin it does not use.
+      # @rbs (Hash[String, untyped]) -> String
+      def content_security_policy(env)
+        sources = [ "'self'", "'nonce-#{env[Web::NONCE_KEY]}'", Web.chart_library_origin ].compact
+        CONTENT_SECURITY_POLICY.sub(SCRIPT_PLACEHOLDER, sources.join(" "))
+      end
+
+      # The cascade header lets a host application serve its own 404 for a path
+      # below the mount that the dashboard does not define.
+      # @rbs () -> Array[untyped]
+      def not_found
+        [ 404, { "content-type" => "text/plain", "x-cascade" => "pass" }, [ "Not Found" ] ]
+      end
+
+      # @rbs () -> Array[untyped]
+      def forbidden
+        [ 403, { "content-type" => "text/plain" }, [ "Forbidden" ] ]
+      end
+    end
+  end
+end

--- a/lib/solid_objects/web/csrf_protection.rb
+++ b/lib/solid_objects/web/csrf_protection.rb
@@ -64,9 +64,13 @@ module SolidObjects
         token = decode(given)
         return false unless token
 
-        # The session token is replaced whether or not this comparison
-        # succeeds, so a token cannot be replayed after it is spent.
-        session[:csrf] = SecureRandom.base64(TOKEN_BYTES)
+        # The secret is not rotated here. A page renders one Retry form per
+        # dead letter, and a browser keeps pages open in other tabs, so
+        # spending the secret on the first submission would answer 403 to
+        # every other form already rendered. Single use is not what a CSRF
+        # token provides: it proves the request came from a page this session
+        # was served, and the per-request mask below is what keeps the value
+        # on the wire from repeating.
         matches?(token, stored)
       end
 

--- a/lib/solid_objects/web/csrf_protection.rb
+++ b/lib/solid_objects/web/csrf_protection.rb
@@ -1,0 +1,126 @@
+# rbs_inline: enabled
+
+require "rack/request"
+require "rack/utils"
+require "securerandom"
+
+module SolidObjects
+  class Web
+    # A state changing request must carry the token of the session that asked
+    # for the form. The token a form receives is masked with a fresh one-time
+    # pad on every request, so the bytes on the wire differ each time and a
+    # compression side channel cannot recover the session token.
+    class CsrfProtection
+      SAFE_METHODS = %w[GET HEAD OPTIONS TRACE].freeze
+      TOKEN_BYTES = 32
+
+      MISSING_SESSION = <<~MESSAGE
+        SolidObjects::Web needs a Rack session for CSRF protection.
+
+        Mount it inside the application routes so the Rails session middleware runs first:
+
+          Rails.application.routes.draw do
+            mount SolidObjects::Web => "/solid_objects"
+          end
+
+        In a bare Rack application, run a session middleware before it:
+
+          use Rack::Session::Cookie, secret: ENV.fetch("SESSION_SECRET"), same_site: true
+          run SolidObjects::Web
+      MESSAGE
+
+      # @rbs (untyped) -> void
+      def initialize(app)
+        @app = app
+      end
+
+      # @rbs (Hash[String, untyped]) -> Array[untyped]
+      def call(env)
+        return forbidden unless accept?(env)
+
+        session = session!(env)
+        session[:csrf] ||= SecureRandom.base64(TOKEN_BYTES)
+        env[Web::CSRF_TOKEN_KEY] = mask(session[:csrf])
+        @app.call(env)
+      end
+
+      private
+
+      # @rbs (Hash[String, untyped]) -> bool
+      def accept?(env)
+        return true if SAFE_METHODS.include?(env["REQUEST_METHOD"])
+
+        valid?(env, ::Rack::Request.new(env).params["authenticity_token"])
+      end
+
+      # @rbs (Hash[String, untyped], String?) -> bool
+      def valid?(env, given)
+        return false if given.nil? || given.empty?
+
+        session = session!(env)
+        stored = session[:csrf]
+        return false if stored.nil?
+
+        token = decode(given)
+        return false unless token
+
+        # The session token is replaced whether or not this comparison
+        # succeeds, so a token cannot be replayed after it is spent.
+        session[:csrf] = SecureRandom.base64(TOKEN_BYTES)
+        matches?(token, stored)
+      end
+
+      # @rbs (String, String) -> bool
+      def matches?(token, stored)
+        candidate = case token.bytesize
+        when TOKEN_BYTES then token
+        when TOKEN_BYTES * 2 then unmask(token)
+        else return false
+        end
+
+        ::Rack::Utils.secure_compare(candidate, decode(stored).to_s)
+      end
+
+      # @rbs (String) -> String
+      def mask(token)
+        decoded = decode(token).to_s
+        pad = SecureRandom.random_bytes(decoded.bytesize)
+        encode(pad + exclusive_or(pad, decoded))
+      end
+
+      # @rbs (String) -> String
+      def unmask(masked)
+        half = masked.bytesize / 2
+        exclusive_or(masked[0, half].to_s, masked[half..].to_s)
+      end
+
+      # @rbs (String, String) -> String
+      def exclusive_or(left, right)
+        left.bytes.zip(right.bytes).map { |first, second| first ^ second.to_i }.pack("c*")
+      end
+
+      # @rbs (String) -> String
+      def encode(token)
+        [ token ].pack("m0").tr("+/", "-_")
+      end
+
+      # @rbs (String) -> String?
+      def decode(token)
+        decoded = token.tr("-_", "+/").unpack1("m0")
+        decoded.is_a?(String) ? decoded : nil
+      rescue ArgumentError
+        nil
+      end
+
+      # @rbs (Hash[String, untyped]) -> Hash[untyped, untyped]
+      def session!(env)
+        env["rack.session"] || raise(MISSING_SESSION)
+      end
+
+      # @rbs () -> Array[untyped]
+      def forbidden
+        [ 403, { "content-type" => "text/plain" }, [ "Forbidden" ] ]
+      end
+    end
+  end
+end

--- a/lib/solid_objects/web/helpers.rb
+++ b/lib/solid_objects/web/helpers.rb
@@ -1,0 +1,227 @@
+# rbs_inline: enabled
+
+require "json"
+require "rack/utils"
+
+module SolidObjects
+  class Web
+    # The methods a view may call. Everything a template prints goes through
+    # `h`, because an actor id, an operation name, and an exception message are
+    # all application supplied strings that reach this page unchanged.
+    module Helpers
+      # Only these survive a page link. A filter an operator set stays set when
+      # they turn the page; anything else the query string carries does not
+      # come back.
+      FORWARDED_PARAMS = %w[actor_type actor_id status per_page].freeze
+      TRUNCATION_LIMIT = 2_000
+
+      # @rbs (untyped) -> String
+      def h(text)
+        ::Rack::Utils.escape_html(text.to_s)
+      end
+
+      # @rbs () -> String
+      def root_path
+        env["SCRIPT_NAME"].to_s
+      end
+
+      # @rbs (String) -> String
+      def path_to(path)
+        "#{root_path}#{path}"
+      end
+
+      # @rbs () -> String
+      def current_path
+        request.path_info
+      end
+
+      # @rbs (String) -> bool
+      def current_tab?(path)
+        return current_path == "/" if path == "/"
+
+        current_path.start_with?(path)
+      end
+
+      # @rbs () -> Hash[String, String]
+      def tabs
+        Web.tabs
+      end
+
+      # @rbs () -> String?
+      def csp_nonce
+        env[Web::NONCE_KEY]
+      end
+
+      # @rbs () -> String
+      def csrf_tag
+        %(<input type="hidden" name="authenticity_token" value="#{h(env[Web::CSRF_TOKEN_KEY])}" />)
+      end
+
+      # @rbs (String) -> String
+      def form_to(path)
+        %(<form method="post" action="#{h(path_to(path))}">#{csrf_tag})
+      end
+
+      # @rbs (untyped) -> String
+      def relative_time(time)
+        return "&mdash;" unless time
+
+        stamp = time.getutc.iso8601
+        %(<time datetime="#{stamp}" title="#{stamp}">#{h(stamp)}</time>)
+      end
+
+      # @rbs (untyped) -> String
+      def number(value)
+        h(value.to_i.to_s.reverse.scan(/\d{1,3}/).join(",").reverse)
+      end
+
+      # @rbs (Numeric?) -> String
+      def duration(seconds)
+        return "&mdash;" unless seconds
+
+        return "#{h(format("%.3f", seconds))} s" if seconds < 60
+
+        h("#{(seconds / 60).floor} min #{(seconds % 60).round} s")
+      end
+
+      # @rbs (untyped, ?Integer) -> String
+      def json_block(value)
+        return "&mdash;" if value.nil?
+
+        %(<pre class="payload">#{h(truncate(JSON.pretty_generate(value)))}</pre>)
+      rescue JSON::GeneratorError, TypeError
+        %(<pre class="payload">#{h(truncate(value.inspect))}</pre>)
+      end
+
+      # @rbs (String, ?Integer) -> String
+      def truncate(text, limit = TRUNCATION_LIMIT)
+        return text if text.length <= limit
+
+        "#{text[0, limit]}…"
+      end
+
+      # @rbs (String?) -> String
+      def status_label(status)
+        %(<span class="status status-#{h(status)}">#{h(status)}</span>)
+      end
+
+      # @rbs (untyped) -> String
+      def actor_label(record)
+        "#{h(record.actor_type)} / #{h(record.actor_id)}"
+      end
+
+      # @rbs (untyped) -> String
+      def instance_link(instance)
+        %(<a href="#{h(path_to("/instances/#{instance.id}"))}">#{actor_label(instance)}</a>)
+      end
+
+      # @rbs (?Hash[String, untyped]) -> String
+      def query_string(overrides = {})
+        merged = FORWARDED_PARAMS
+          .to_h { |name| [ name, url_params(name) ] }
+          .merge(overrides.transform_keys(&:to_s))
+          .reject { |_name, value| value.nil? || value.to_s.empty? }
+        return "" if merged.empty?
+
+        "?#{merged.map { |name, value| "#{::Rack::Utils.escape(name)}=#{::Rack::Utils.escape(value.to_s)}" }.join("&")}"
+      end
+
+      # @rbs (?Hash[String, untyped]) -> String
+      def page_link(overrides = {})
+        h("#{path_to(current_path)}#{query_string(overrides)}")
+      end
+
+      # @rbs (Instance) -> String
+      def lease_state(instance)
+        return "paused" if instance.paused_at
+        return "idle" unless instance.activation_owner_id
+        return "idle" unless instance.activation_expires_at
+
+        (instance.activation_expires_at > statistics.now) ? "activated" : "expired"
+      end
+
+      # @rbs () -> Statistics
+      def statistics
+        @statistics ||= Statistics.new
+      end
+
+      # @rbs (untyped) -> Paginator
+      def paginate(relation)
+        Paginator.new(relation:, page: url_params("page"), per_page: url_params("per_page"))
+      end
+
+      # An unrecognized filter falls back to the default rather than returning
+      # nothing, so a hand edited query string cannot make a page look empty.
+      # @rbs (Array[String], ?default: String?) -> String?
+      def filter_value(allowed, default: nil)
+        value = url_params("status")
+        allowed.include?(value) ? value : default
+      end
+
+      # @rbs () -> Instance
+      def find_instance
+        instance = Instance.find_by(id: route_params(:id))
+        halt(404) unless instance
+
+        instance
+      end
+
+      # @rbs () -> untyped
+      def filtered_instances
+        relation = Instance.order(updated_at: :desc, id: :desc)
+        actor_type = url_params("actor_type")
+        relation = relation.where(actor_type:) unless actor_type.to_s.empty?
+        actor_id = url_params("actor_id")
+        return relation if actor_id.to_s.empty?
+
+        relation.where(
+          Instance.arel_table[:actor_id].matches("%#{Instance.sanitize_sql_like(actor_id)}%")
+        )
+      end
+
+      # @rbs (String) -> untyped
+      def mailbox_messages(membership)
+        membership_model = (membership == "claimed") ? ClaimedMessage : ReadyMessage
+        Message
+          .where(id: membership_model.select(:message_id))
+          .order(available_at: :asc, id: :asc)
+      end
+
+      # Chart data travels in an attribute rather than an inline script block,
+      # so the page needs no script-src exception and an actor type cannot
+      # close the attribute and open a tag.
+      #
+      # The container is not decoration. Chart.js measures a responsive canvas
+      # against its parent, so the parent has to have a height of its own; a
+      # panel that sizes to its children would grow a little on every redraw.
+      # @rbs (String, untyped) -> String
+      def chart(name, values)
+        return "" unless Web.charts?
+
+        %(<div class="chart-frame"><canvas data-chart="#{h(name)}" ) +
+          %(data-chart-values='#{h(JSON.generate(values))}'></canvas></div>)
+      end
+
+      # A vendored copy is a path below the mount; a CDN copy is an absolute
+      # URL and is left alone.
+      # @rbs () -> String
+      def chart_library_source
+        url = Web.chart_library_url.to_s
+        url.include?("//") ? url : path_to(url)
+      end
+
+      # @rbs () -> String
+      def chart_library_integrity_attributes
+        integrity = Web.chart_library_integrity
+        return "" unless integrity
+
+        %( integrity="#{h(integrity)}" crossorigin="anonymous" referrerpolicy="no-referrer")
+      end
+
+      # @rbs () -> String
+      def environment_name
+        ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+      end
+    end
+  end
+end

--- a/lib/solid_objects/web/paginator.rb
+++ b/lib/solid_objects/web/paginator.rb
@@ -1,0 +1,64 @@
+# rbs_inline: enabled
+
+module SolidObjects
+  class Web
+    # Counts and slices one relation. The page size is clamped because the page
+    # number and the page size both arrive from the query string, and an
+    # operator page that accepts an unbounded limit is a denial of service
+    # against the database the actors run on.
+    class Paginator
+      DEFAULT_PER_PAGE = 25
+      MAXIMUM_PER_PAGE = 200
+
+      # @rbs @page: Integer
+      # @rbs @per_page: Integer
+      # @rbs @total: Integer
+      # @rbs @records: Array[untyped]
+
+      attr_reader :page, :per_page, :total, :records
+
+      # @rbs (relation: untyped, ?page: String?, ?per_page: String?) -> void
+      def initialize(relation:, page: nil, per_page: nil)
+        @per_page = bounded(per_page, default: DEFAULT_PER_PAGE, maximum: MAXIMUM_PER_PAGE)
+        @total = relation.count
+        @page = bounded(page, default: 1, maximum: last_page)
+        @records = relation.offset((@page - 1) * @per_page).limit(@per_page).to_a
+      end
+
+      # @rbs () -> Integer
+      def last_page
+        [ (total.to_f / per_page).ceil, 1 ].max
+      end
+
+      # @rbs () -> Integer?
+      def previous_page
+        (page > 1) ? page - 1 : nil
+      end
+
+      # @rbs () -> Integer?
+      def next_page
+        (page < last_page) ? page + 1 : nil
+      end
+
+      # @rbs () -> Integer
+      def first_record
+        total.zero? ? 0 : ((page - 1) * per_page) + 1
+      end
+
+      # @rbs () -> Integer
+      def last_record
+        [ page * per_page, total ].min
+      end
+
+      private
+
+      # @rbs (String?, default: Integer, maximum: Integer) -> Integer
+      def bounded(value, default:, maximum:)
+        requested = Integer(value.to_s, 10, exception: false)
+        return default unless requested&.positive?
+
+        [ requested, maximum ].min
+      end
+    end
+  end
+end

--- a/lib/solid_objects/web/route.rb
+++ b/lib/solid_objects/web/route.rb
@@ -1,0 +1,55 @@
+# rbs_inline: enabled
+
+module SolidObjects
+  class Web
+    class Route
+      # A named segment stops at the next slash, so `/instances/:id` never
+      # swallows `/instances/1/pause` and route order cannot hide a page.
+      NAMED_SEGMENT = %r{/([^/]*):([^.:$/]+)}
+      SEGMENT_CAPTURE = '/\1(?<\2>[^$/]+)'
+
+      # @rbs @matcher: String | Regexp
+      # @rbs @request_method: String
+      # @rbs @pattern: String
+      # @rbs @policy: Hash[Symbol, String]
+      # @rbs @handler: Proc
+
+      attr_reader :request_method, :pattern, :policy, :handler
+
+      # @rbs (request_method: String, pattern: String, policy: Hash[Symbol, String], handler: Proc) -> void
+      def initialize(request_method:, pattern:, policy:, handler:)
+        @request_method = request_method
+        @pattern = pattern
+        @policy = policy
+        @handler = handler
+        @matcher = compile(pattern)
+      end
+
+      # @rbs (String) -> bool
+      def match?(path)
+        return @matcher == path if @matcher.is_a?(String)
+
+        @matcher.match?(path)
+      end
+
+      # @rbs (String) -> Hash[Symbol, String?]
+      def capture(path)
+        return {} if @matcher.is_a?(String)
+
+        match = @matcher.match(path)
+        return {} unless match
+
+        match.named_captures.transform_keys(&:to_sym)
+      end
+
+      private
+
+      # @rbs (String) -> (String | Regexp)
+      def compile(pattern)
+        return pattern unless pattern.match?(NAMED_SEGMENT)
+
+        Regexp.new("\\A#{pattern.gsub(NAMED_SEGMENT, SEGMENT_CAPTURE)}\\z")
+      end
+    end
+  end
+end

--- a/lib/solid_objects/web/router.rb
+++ b/lib/solid_objects/web/router.rb
@@ -1,0 +1,46 @@
+# rbs_inline: enabled
+
+module SolidObjects
+  class Web
+    # Declares the pages of the dashboard. Every route carries the
+    # administration policy it needs, and a route declared without one raises
+    # at load time. A new page therefore cannot reach the database before an
+    # application has said who may read it.
+    module Router
+      # @rbs (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+      def head(path, policy: nil, &handler)
+        route("HEAD", path, policy:, &handler)
+      end
+
+      # @rbs (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+      def get(path, policy: nil, &handler)
+        route("GET", path, policy:, &handler)
+      end
+
+      # @rbs (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+      def post(path, policy: nil, &handler)
+        route("POST", path, policy:, &handler)
+      end
+
+      # @rbs (String, String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+      def route(request_method, path, policy: nil, &handler)
+        raise ArgumentError, "route #{path} requires an authorization policy" unless policy
+        raise ArgumentError, "route #{path} requires a handler" unless handler
+        raise ArgumentError, "route #{path} requires a policy action" unless policy[:action]
+        raise ArgumentError, "route #{path} requires a policy resource" unless policy[:resource]
+
+        routes[request_method] << Route.new(request_method:, pattern: path, policy:, handler:)
+      end
+
+      # @rbs () -> Hash[String, Array[Route]]
+      def routes
+        @routes ||= Hash.new { |store, request_method| store[request_method] = [] }
+      end
+
+      # @rbs (String, String) -> Route?
+      def match(request_method, path)
+        routes[request_method].find { |route| route.match?(path) }
+      end
+    end
+  end
+end

--- a/lib/solid_objects/web/statistics.rb
+++ b/lib/solid_objects/web/statistics.rb
@@ -1,0 +1,78 @@
+# rbs_inline: enabled
+
+module SolidObjects
+  class Web
+    # The counts behind the dashboard and behind `GET /stats`. Both read the
+    # same object, so the polled JSON and the rendered page can never disagree
+    # about what a number means.
+    class Statistics
+      EFFECT_STATUSES = %w[pending processing completed dead].freeze
+      BROADCAST_STATUSES = %w[pending processing delivered dead].freeze
+      REMINDER_STATUSES = %w[scheduled paused completed].freeze
+      PROCESS_STATES = %w[running draining stopped].freeze
+
+      # @rbs @now: Time
+
+      attr_reader :now
+
+      # @rbs (?now: Time) -> void
+      def initialize(now: SolidObjects.database_adapter.database_now)
+        @now = now
+      end
+
+      # @rbs () -> Hash[Symbol, untyped]
+      def to_h
+        {
+          instances:,
+          mailbox:,
+          effects: grouped(Effect, :status, EFFECT_STATUSES),
+          broadcasts: grouped(Broadcast, :status, BROADCAST_STATUSES),
+          reminders:,
+          dead_letters: { total: DeadLetter.count },
+          processes: grouped(Process, :shutdown_state, PROCESS_STATES),
+          server_time: now.utc.iso8601
+        }
+      end
+
+      # @rbs () -> Hash[Symbol, Integer]
+      def instances
+        {
+          total: Instance.count,
+          paused: Instance.where.not(paused_at: nil).count,
+          activated: Instance.where(activation_expires_at: now..).count
+        }
+      end
+
+      # The oldest ready message that is already due is the queue latency of
+      # this runtime: how far behind the workers are, in seconds.
+      # @rbs () -> Hash[Symbol, untyped]
+      def mailbox
+        due = ReadyMessage.where(available_at: ..now)
+        oldest = due.minimum(:available_at)
+        {
+          ready: ReadyMessage.count,
+          due: due.count,
+          claimed: ClaimedMessage.count,
+          latency: oldest ? (now - oldest).round(3) : 0.0
+        }
+      end
+
+      # @rbs () -> Hash[Symbol, Integer]
+      def reminders
+        grouped(Reminder, :status, REMINDER_STATUSES).merge(
+          due: Reminder.where(status: "scheduled", next_run_at: ..now).count
+        )
+      end
+
+      private
+
+      # A status the schema allows but the table does not currently hold still
+      # reports zero, so a row of counts keeps the same shape between polls.
+      # @rbs (untyped, Symbol, Array[String]) -> Hash[Symbol, Integer]
+      def grouped(model, column, statuses)
+        counts = model.group(column).count
+        statuses.to_h { |status| [ status.to_sym, counts.fetch(status, 0) ] }
+      end
+    end
+  end
+end

--- a/sig/generated/lib/solid_objects/web.rbs
+++ b/sig/generated/lib/solid_objects/web.rbs
@@ -1,0 +1,129 @@
+# Generated from lib/solid_objects/web.rb with RBS::Inline
+
+module SolidObjects
+  # An operator dashboard for the actor runtime, served as a Rack application:
+  #
+  #   Rails.application.routes.draw do
+  #     mount SolidObjects::Web => "/solid_objects"
+  #   end
+  #
+  # It is deliberately not loaded by `require "solid_objects"`. A worker
+  # process must not carry a web stack, and an application that never mounts
+  # the dashboard must not pay for it.
+  #
+  # Every page asks `configuration.authorize_administration` first. That block
+  # denies by default, so a mount alone exposes nothing until an application
+  # states who may read it.
+  class Web
+    ROOT: untyped
+
+    VIEWS: untyped
+
+    ASSETS: untyped
+
+    NONCE_KEY: ::String
+
+    CSRF_TOKEN_KEY: ::String
+
+    NONCE_BYTES: ::Integer
+
+    ASSET_CACHE_SECONDS: ::Integer
+
+    TEMPLATE_NAME: ::Regexp
+
+    # The dashboard charts need a charting library, and this one is fetched
+    # from a public CDN with a subresource integrity hash, so a compromised CDN
+    # cannot substitute other code. A deployment with no outbound network
+    # access should vendor the file and point `chart_library_url` at it, or set
+    # that to nil to render the dashboard without charts.
+    CHART_LIBRARY_URL: ::String
+
+    CHART_LIBRARY_INTEGRITY: ::String
+
+    DEFAULT_TABS: untyped
+
+    LOCK: untyped
+
+    # A path below the mount serves a vendored copy; an absolute URL is
+    # fetched from that host and is named in the content security policy.
+    # nil renders the dashboard without charts.
+    # @rbs @chart_library_url: String?
+    # @rbs @chart_library_integrity: String?
+    attr_writer chart_library_url: untyped
+
+    # A path below the mount serves a vendored copy; an absolute URL is
+    # fetched from that host and is named in the content security policy.
+    # nil renders the dashboard without charts.
+    # @rbs @chart_library_url: String?
+    # @rbs @chart_library_integrity: String?
+    attr_writer chart_library_integrity: untyped
+
+    # @rbs () -> String?
+    def self.chart_library_url: () -> String?
+
+    # @rbs () -> String?
+    def self.chart_library_integrity: () -> String?
+
+    # @rbs () -> bool
+    def self.charts?: () -> bool
+
+    # The origin the content security policy has to allow. A vendored copy
+    # served from the mount has none, so the policy stays at 'self'.
+    # @rbs () -> String?
+    def self.chart_library_origin: () -> String?
+
+    # @rbs () -> Hash[String, String]
+    def self.tabs: () -> Hash[String, String]
+
+    # Searched in order, so an extension directory added first wins over the
+    # packaged one and an application can replace a single page.
+    # @rbs () -> Array[String]
+    def self.views: () -> Array[String]
+
+    # @rbs () -> Array[[Array[untyped], Proc?]]
+    def self.middlewares: () -> Array[[ Array[untyped], Proc? ]]
+
+    # The built stack is memoized, so a middleware added after the first
+    # request would otherwise be dropped without a word.
+    # @rbs (*untyped) ?{ () -> untyped } -> void
+    def self.use: (*untyped) ?{ () -> untyped } -> void
+
+    # Adds pages to the dashboard. The extension receives the application
+    # class and declares its own routes on it, which means its routes carry
+    # an authorization policy like every other route.
+    #
+    # @rbs (untyped, tab: String, path: String, ?views: String?) -> void
+    def self.register: (untyped, tab: String, path: String, ?views: String?) -> void
+
+    # @rbs (Symbol) -> untyped
+    def self.template: (Symbol) -> untyped
+
+    # @rbs () -> void
+    def self.reset!: () -> void
+
+    # @rbs (Hash[String, untyped]) -> Array[untyped]
+    def self.call: (Hash[String, untyped]) -> Array[untyped]
+
+    # @rbs () -> Web
+    def self.application: () -> Web
+
+    # @rbs () -> Hash[Symbol, untyped]
+    private def self.templates: () -> Hash[Symbol, untyped]
+
+    # A template name never comes from a request, and this keeps it that way
+    # rather than trusting every future caller to know it.
+    # @rbs (Symbol) -> String
+    private def self.template_path: (Symbol) -> String
+
+    # @rbs (Hash[String, untyped]) -> Array[untyped]
+    def call: (Hash[String, untyped]) -> Array[untyped]
+
+    # @rbs () -> untyped
+    def app: () -> untyped
+
+    private
+
+    # @rbs () -> untyped
+    def build: () -> untyped
+  end
+end

--- a/sig/generated/lib/solid_objects/web/action.rbs
+++ b/sig/generated/lib/solid_objects/web/action.rbs
@@ -1,0 +1,78 @@
+# Generated from lib/solid_objects/web/action.rb with RBS::Inline
+
+module SolidObjects
+  class Web
+    # One request. A route handler runs inside an instance of this class, so a
+    # handler and the template it renders share the same helpers and the same
+    # request.
+    class Action
+      include Helpers
+
+      @response_status: Integer
+
+      @layout_rendered: bool
+
+      @request: untyped
+
+      @captures: Hash[Symbol, String?]
+
+      @route: Route
+
+      @env: Hash[String, untyped]
+
+      attr_reader env: untyped
+
+      attr_reader route: untyped
+
+      attr_reader response_status: untyped
+
+      # @rbs (env: Hash[String, untyped], route: Route) -> void
+      def initialize: (env: Hash[String, untyped], route: Route) -> void
+
+      # Sets the status a rendered page is served with. `halt` and `redirect`
+      # stop the handler, so a page that must render its own body and still
+      # report a failure needs this instead.
+      # @rbs (Integer) -> void
+      def status: (Integer) -> void
+
+      # @rbs () -> untyped
+      def request: () -> untyped
+
+      # @rbs () -> Hash[untyped, untyped]?
+      def session: () -> Hash[untyped, untyped]?
+
+      # @rbs (Symbol) -> String?
+      def route_params: (Symbol) -> String?
+
+      # @rbs (String) -> untyped
+      def url_params: (String) -> untyped
+
+      # @rbs () -> untyped
+      def call: () -> untyped
+
+      # The layout is rendered once per request. The flag is raised before the
+      # page body runs so a partial the body renders returns its own fragment
+      # rather than a second whole page. The layout reads the page it wraps
+      # from `locals.fetch(:content)`.
+      # @rbs (Symbol, ?Hash[Symbol, untyped]) -> String
+      def erb: (Symbol, ?Hash[Symbol, untyped]) -> String
+
+      # @rbs (Integer, ?String) -> void
+      def halt: (Integer, ?String) -> void
+
+      # @rbs (String) -> void
+      def redirect: (String) -> void
+
+      # @rbs (untyped) -> void
+      def json: (untyped) -> void
+
+      private
+
+      # `locals` is a local variable of this method, so a template reads it by
+      # name, and every helper is reachable because the template runs against
+      # this object.
+      # @rbs (untyped, Hash[Symbol, untyped]) -> String
+      def evaluate: (untyped, Hash[Symbol, untyped]) -> String
+    end
+  end
+end

--- a/sig/generated/lib/solid_objects/web/application.rbs
+++ b/sig/generated/lib/solid_objects/web/application.rbs
@@ -1,0 +1,50 @@
+# Generated from lib/solid_objects/web/application.rb with RBS::Inline
+
+module SolidObjects
+  class Web
+    # The pages. Each route states the administration policy it needs, and
+    # `call` asks that policy before the handler runs, so a page cannot read
+    # the actor tables on behalf of an unauthorized request.
+    class Application
+      extend Router
+
+      SCRIPT_PLACEHOLDER: ::String
+
+      CONTENT_SECURITY_POLICY: untyped
+
+      MAILBOX_MEMBERSHIPS: untyped
+
+      RECENT_LIMIT: ::Integer
+
+      CHART_TYPE_LIMIT: ::Integer
+
+      # @rbs (Hash[String, untyped]) -> Array[untyped]
+      def call: (Hash[String, untyped]) -> Array[untyped]
+
+      private
+
+      # @rbs (Action, untyped) -> Array[untyped]
+      def respond: (Action, untyped) -> Array[untyped]
+
+      # @rbs (Action) -> bool
+      def authorized?: (Action) -> bool
+
+      # @rbs (Hash[String, untyped]) -> Hash[String, String]
+      def page_headers: (Hash[String, untyped]) -> Hash[String, String]
+
+      # The chart host is named only when one is configured, so a deployment
+      # that vendors the library or turns charts off never advertises a third
+      # party origin it does not use.
+      # @rbs (Hash[String, untyped]) -> String
+      def content_security_policy: (Hash[String, untyped]) -> String
+
+      # The cascade header lets a host application serve its own 404 for a path
+      # below the mount that the dashboard does not define.
+      # @rbs () -> Array[untyped]
+      def not_found: () -> Array[untyped]
+
+      # @rbs () -> Array[untyped]
+      def forbidden: () -> Array[untyped]
+    end
+  end
+end

--- a/sig/generated/lib/solid_objects/web/csrf_protection.rbs
+++ b/sig/generated/lib/solid_objects/web/csrf_protection.rbs
@@ -1,0 +1,55 @@
+# Generated from lib/solid_objects/web/csrf_protection.rb with RBS::Inline
+
+module SolidObjects
+  class Web
+    # A state changing request must carry the token of the session that asked
+    # for the form. The token a form receives is masked with a fresh one-time
+    # pad on every request, so the bytes on the wire differ each time and a
+    # compression side channel cannot recover the session token.
+    class CsrfProtection
+      SAFE_METHODS: untyped
+
+      TOKEN_BYTES: ::Integer
+
+      MISSING_SESSION: ::String
+
+      # @rbs (untyped) -> void
+      def initialize: (untyped) -> void
+
+      # @rbs (Hash[String, untyped]) -> Array[untyped]
+      def call: (Hash[String, untyped]) -> Array[untyped]
+
+      private
+
+      # @rbs (Hash[String, untyped]) -> bool
+      def accept?: (Hash[String, untyped]) -> bool
+
+      # @rbs (Hash[String, untyped], String?) -> bool
+      def valid?: (Hash[String, untyped], String?) -> bool
+
+      # @rbs (String, String) -> bool
+      def matches?: (String, String) -> bool
+
+      # @rbs (String) -> String
+      def mask: (String) -> String
+
+      # @rbs (String) -> String
+      def unmask: (String) -> String
+
+      # @rbs (String, String) -> String
+      def exclusive_or: (String, String) -> String
+
+      # @rbs (String) -> String
+      def encode: (String) -> String
+
+      # @rbs (String) -> String?
+      def decode: (String) -> String?
+
+      # @rbs (Hash[String, untyped]) -> Hash[untyped, untyped]
+      def session!: (Hash[String, untyped]) -> Hash[untyped, untyped]
+
+      # @rbs () -> Array[untyped]
+      def forbidden: () -> Array[untyped]
+    end
+  end
+end

--- a/sig/generated/lib/solid_objects/web/helpers.rbs
+++ b/sig/generated/lib/solid_objects/web/helpers.rbs
@@ -1,0 +1,118 @@
+# Generated from lib/solid_objects/web/helpers.rb with RBS::Inline
+
+module SolidObjects
+  class Web
+    # The methods a view may call. Everything a template prints goes through
+    # `h`, because an actor id, an operation name, and an exception message are
+    # all application supplied strings that reach this page unchanged.
+    module Helpers
+      # Only these survive a page link. A filter an operator set stays set when
+      # they turn the page; anything else the query string carries does not
+      # come back.
+      FORWARDED_PARAMS: untyped
+
+      TRUNCATION_LIMIT: ::Integer
+
+      # @rbs (untyped) -> String
+      def h: (untyped) -> String
+
+      # @rbs () -> String
+      def root_path: () -> String
+
+      # @rbs (String) -> String
+      def path_to: (String) -> String
+
+      # @rbs () -> String
+      def current_path: () -> String
+
+      # @rbs (String) -> bool
+      def current_tab?: (String) -> bool
+
+      # @rbs () -> Hash[String, String]
+      def tabs: () -> Hash[String, String]
+
+      # @rbs () -> String?
+      def csp_nonce: () -> String?
+
+      # @rbs () -> String
+      def csrf_tag: () -> String
+
+      # @rbs (String) -> String
+      def form_to: (String) -> String
+
+      # @rbs (untyped) -> String
+      def relative_time: (untyped) -> String
+
+      # @rbs (untyped) -> String
+      def number: (untyped) -> String
+
+      # @rbs (Numeric?) -> String
+      def duration: (Numeric?) -> String
+
+      # @rbs (untyped, ?Integer) -> String
+      def json_block: (untyped, ?Integer) -> String
+
+      # @rbs (String, ?Integer) -> String
+      def truncate: (String, ?Integer) -> String
+
+      # @rbs (String?) -> String
+      def status_label: (String?) -> String
+
+      # @rbs (untyped) -> String
+      def actor_label: (untyped) -> String
+
+      # @rbs (untyped) -> String
+      def instance_link: (untyped) -> String
+
+      # @rbs (?Hash[String, untyped]) -> String
+      def query_string: (?Hash[String, untyped]) -> String
+
+      # @rbs (?Hash[String, untyped]) -> String
+      def page_link: (?Hash[String, untyped]) -> String
+
+      # @rbs (Instance) -> String
+      def lease_state: (Instance) -> String
+
+      # @rbs () -> Statistics
+      def statistics: () -> Statistics
+
+      # @rbs (untyped) -> Paginator
+      def paginate: (untyped) -> Paginator
+
+      # An unrecognized filter falls back to the default rather than returning
+      # nothing, so a hand edited query string cannot make a page look empty.
+      # @rbs (Array[String], ?default: String?) -> String?
+      def filter_value: (Array[String], ?default: String?) -> String?
+
+      # @rbs () -> Instance
+      def find_instance: () -> Instance
+
+      # @rbs () -> untyped
+      def filtered_instances: () -> untyped
+
+      # @rbs (String) -> untyped
+      def mailbox_messages: (String) -> untyped
+
+      # Chart data travels in an attribute rather than an inline script block,
+      # so the page needs no script-src exception and an actor type cannot
+      # close the attribute and open a tag.
+      #
+      # The container is not decoration. Chart.js measures a responsive canvas
+      # against its parent, so the parent has to have a height of its own; a
+      # panel that sizes to its children would grow a little on every redraw.
+      # @rbs (String, untyped) -> String
+      def chart: (String, untyped) -> String
+
+      # A vendored copy is a path below the mount; a CDN copy is an absolute
+      # URL and is left alone.
+      # @rbs () -> String
+      def chart_library_source: () -> String
+
+      # @rbs () -> String
+      def chart_library_integrity_attributes: () -> String
+
+      # @rbs () -> String
+      def environment_name: () -> String
+    end
+  end
+end

--- a/sig/generated/lib/solid_objects/web/paginator.rbs
+++ b/sig/generated/lib/solid_objects/web/paginator.rbs
@@ -1,0 +1,54 @@
+# Generated from lib/solid_objects/web/paginator.rb with RBS::Inline
+
+module SolidObjects
+  class Web
+    # Counts and slices one relation. The page size is clamped because the page
+    # number and the page size both arrive from the query string, and an
+    # operator page that accepts an unbounded limit is a denial of service
+    # against the database the actors run on.
+    class Paginator
+      DEFAULT_PER_PAGE: ::Integer
+
+      MAXIMUM_PER_PAGE: ::Integer
+
+      @page: Integer
+
+      @per_page: Integer
+
+      @total: Integer
+
+      @records: Array[untyped]
+
+      attr_reader page: untyped
+
+      attr_reader per_page: untyped
+
+      attr_reader total: untyped
+
+      attr_reader records: untyped
+
+      # @rbs (relation: untyped, ?page: String?, ?per_page: String?) -> void
+      def initialize: (relation: untyped, ?page: String?, ?per_page: String?) -> void
+
+      # @rbs () -> Integer
+      def last_page: () -> Integer
+
+      # @rbs () -> Integer?
+      def previous_page: () -> Integer?
+
+      # @rbs () -> Integer?
+      def next_page: () -> Integer?
+
+      # @rbs () -> Integer
+      def first_record: () -> Integer
+
+      # @rbs () -> Integer
+      def last_record: () -> Integer
+
+      private
+
+      # @rbs (String?, default: Integer, maximum: Integer) -> Integer
+      def bounded: (String?, default: Integer, maximum: Integer) -> Integer
+    end
+  end
+end

--- a/sig/generated/lib/solid_objects/web/route.rbs
+++ b/sig/generated/lib/solid_objects/web/route.rbs
@@ -1,0 +1,45 @@
+# Generated from lib/solid_objects/web/route.rb with RBS::Inline
+
+module SolidObjects
+  class Web
+    class Route
+      # A named segment stops at the next slash, so `/instances/:id` never
+      # swallows `/instances/1/pause` and route order cannot hide a page.
+      NAMED_SEGMENT: ::Regexp
+
+      SEGMENT_CAPTURE: ::String
+
+      @matcher: String | Regexp
+
+      @request_method: String
+
+      @pattern: String
+
+      @policy: Hash[Symbol, String]
+
+      @handler: Proc
+
+      attr_reader request_method: untyped
+
+      attr_reader pattern: untyped
+
+      attr_reader policy: untyped
+
+      attr_reader handler: untyped
+
+      # @rbs (request_method: String, pattern: String, policy: Hash[Symbol, String], handler: Proc) -> void
+      def initialize: (request_method: String, pattern: String, policy: Hash[Symbol, String], handler: Proc) -> void
+
+      # @rbs (String) -> bool
+      def match?: (String) -> bool
+
+      # @rbs (String) -> Hash[Symbol, String?]
+      def capture: (String) -> Hash[Symbol, String?]
+
+      private
+
+      # @rbs (String) -> (String | Regexp)
+      def compile: (String) -> (String | Regexp)
+    end
+  end
+end

--- a/sig/generated/lib/solid_objects/web/router.rbs
+++ b/sig/generated/lib/solid_objects/web/router.rbs
@@ -1,0 +1,29 @@
+# Generated from lib/solid_objects/web/router.rb with RBS::Inline
+
+module SolidObjects
+  class Web
+    # Declares the pages of the dashboard. Every route carries the
+    # administration policy it needs, and a route declared without one raises
+    # at load time. A new page therefore cannot reach the database before an
+    # application has said who may read it.
+    module Router
+      # @rbs (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+      def head: (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+
+      # @rbs (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+      def get: (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+
+      # @rbs (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+      def post: (String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+
+      # @rbs (String, String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+      def route: (String, String, policy: Hash[Symbol, String]?) { () -> untyped } -> void
+
+      # @rbs () -> Hash[String, Array[Route]]
+      def routes: () -> Hash[String, Array[Route]]
+
+      # @rbs (String, String) -> Route?
+      def match: (String, String) -> Route?
+    end
+  end
+end

--- a/sig/generated/lib/solid_objects/web/statistics.rbs
+++ b/sig/generated/lib/solid_objects/web/statistics.rbs
@@ -1,0 +1,46 @@
+# Generated from lib/solid_objects/web/statistics.rb with RBS::Inline
+
+module SolidObjects
+  class Web
+    # The counts behind the dashboard and behind `GET /stats`. Both read the
+    # same object, so the polled JSON and the rendered page can never disagree
+    # about what a number means.
+    class Statistics
+      EFFECT_STATUSES: untyped
+
+      BROADCAST_STATUSES: untyped
+
+      REMINDER_STATUSES: untyped
+
+      PROCESS_STATES: untyped
+
+      @now: Time
+
+      attr_reader now: untyped
+
+      # @rbs (?now: Time) -> void
+      def initialize: (?now: Time) -> void
+
+      # @rbs () -> Hash[Symbol, untyped]
+      def to_h: () -> Hash[Symbol, untyped]
+
+      # @rbs () -> Hash[Symbol, Integer]
+      def instances: () -> Hash[Symbol, Integer]
+
+      # The oldest ready message that is already due is the queue latency of
+      # this runtime: how far behind the workers are, in seconds.
+      # @rbs () -> Hash[Symbol, untyped]
+      def mailbox: () -> Hash[Symbol, untyped]
+
+      # @rbs () -> Hash[Symbol, Integer]
+      def reminders: () -> Hash[Symbol, Integer]
+
+      private
+
+      # A status the schema allows but the table does not currently hold still
+      # reports zero, so a row of counts keeps the same shape between polls.
+      # @rbs (untyped, Symbol, Array[String]) -> Hash[Symbol, Integer]
+      def grouped: (untyped, Symbol, Array[String]) -> Hash[Symbol, Integer]
+    end
+  end
+end

--- a/solid_objects.gemspec
+++ b/solid_objects.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.3"
 
   spec.files = Dir[
-    "{app,benchmark,config,db,docs,examples,exe,lib,sig}/**/*",
+    "{app,benchmark,config,db,docs,examples,exe,lib,sig,web}/**/*",
     "CHANGELOG.md",
     "README.md",
     "Rakefile",
@@ -40,6 +40,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "actionview", ">= 8.0"
   spec.add_dependency "activerecord", ">= 8.0"
   spec.add_dependency "activesupport", ">= 8.0"
+  # The operator dashboard is a Rack application. Rack arrives with Action Pack
+  # in every supported Rails version; the floor is stated because the dashboard
+  # writes lowercase response headers, which Rack 3 requires.
+  spec.add_dependency "rack", ">= 3.1"
   spec.add_dependency "railties", ">= 8.0"
   spec.add_dependency "thor", ">= 1.3"
 

--- a/test/dummy/web_mount_check.rb
+++ b/test/dummy/web_mount_check.rb
@@ -50,7 +50,9 @@ def pause(request, path, cookie, token)
   request.post("#{path}/pause", options)
 end
 
-forged = pause(request, detail_path, cookie, "forged")
+# Well formed and the right length, so it reaches the comparison rather than
+# being turned away by the length check on the way in.
+forged = pause(request, detail_path, cookie, SecureRandom.base64(32))
 forged_paused = instance.reload.paused_at
 
 paused = pause(request, detail_path, cookie, token)

--- a/test/dummy/web_mount_check.rb
+++ b/test/dummy/web_mount_check.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# A Rack application behaves differently under a real Rails router than under a
+# mock environment: the mount supplies SCRIPT_NAME, the session middleware
+# supplies the session CSRF protection needs, and a nested mount depends on the
+# engine cascading paths it does not serve. None of that is exercised by
+# calling the dashboard directly, so this runs it where it actually runs.
+
+ENV["RAILS_ENV"] = "test"
+
+require_relative "config/environment"
+require "solid_objects/web"
+require "rack/mock_request"
+require_relative "../../db/migrate/20260805000000_create_solid_objects_tables"
+require_relative "../../db/migrate/20260806000000_add_state_revision_to_solid_objects_instances"
+require_relative "../../db/migrate/20260813000000_rename_message_dispatch_columns"
+
+ActiveRecord::Migration.verbose = false
+CreateSolidObjectsTables.new.migrate(:up)
+AddStateRevisionToSolidObjectsInstances.new.migrate(:up)
+RenameMessageDispatchColumns.new.migrate(:up)
+
+instance = SolidObjects::Instance.create!(
+  actor_type: "MountCheckActor",
+  actor_id: "only-one",
+  state: { "value" => 7 }
+)
+
+Rails.application.routes.draw do
+  mount SolidObjects::Engine => "/solid_objects"
+  mount SolidObjects::Web => "/solid_objects/dashboard"
+end
+
+request = Rack::MockRequest.new(Rails.application)
+
+SolidObjects.configuration.authorize_administration = ->(**) { false }
+denied = request.get("https://example.com/solid_objects/dashboard/instances")
+
+SolidObjects.configuration.authorize_administration = ->(**) { true }
+allowed = request.get("https://example.com/solid_objects/dashboard/instances")
+
+detail_path = "https://example.com/solid_objects/dashboard/instances/#{instance.id}"
+detail = request.get(detail_path)
+cookie = detail.headers["set-cookie"].to_s.split(";").first.to_s
+token = detail.body[/name="authenticity_token" value="([^"]+)"/, 1].to_s
+
+def pause(request, path, cookie, token)
+  options = { params: { "authenticity_token" => token } }
+  options["HTTP_COOKIE"] = cookie
+  request.post("#{path}/pause", options)
+end
+
+forged = pause(request, detail_path, cookie, "forged")
+forged_paused = instance.reload.paused_at
+
+paused = pause(request, detail_path, cookie, token)
+
+puts "denied=#{denied.status}"
+puts "allowed=#{allowed.status}"
+puts "actor=#{allowed.body.include?("MountCheckActor")}"
+puts "mounted_link=#{allowed.body.include?("/solid_objects/dashboard/stylesheets/application.css")}"
+puts "session=#{allowed.headers["set-cookie"].to_s.include?("_dummy_session")}"
+puts "forged=#{forged.status}"
+puts "forged_paused=#{!forged_paused.nil?}"
+puts "paused=#{paused.status}"
+puts "paused_location=#{paused.headers["location"]}"
+puts "paused_at=#{!instance.reload.paused_at.nil?}"

--- a/test/fixtures/web_extension/_probe.erb
+++ b/test/fixtures/web_extension/_probe.erb
@@ -1,0 +1,3 @@
+<section class="panel">
+  <h2>probe page</h2>
+</section>

--- a/test/fixtures/web_extension/_summary.erb
+++ b/test/fixtures/web_extension/_summary.erb
@@ -1,0 +1,1 @@
+<section class="summary">replaced summary</section>

--- a/test/integration/load_contract_test.rb
+++ b/test/integration/load_contract_test.rb
@@ -21,7 +21,16 @@ class LoadContractTest < ActiveSupport::TestCase
     "errors" => "defines error classes individually, so no SolidObjects::Errors exists",
     "sync_diagnostics" => "the caller path, required with the client",
     "synchronous_invocation" => "the caller path, required with the client",
-    "test_helper" => "opt-in, required by host application tests"
+    "test_helper" => "opt-in, required by host application tests",
+    "web" => "the operator dashboard, required by an application that mounts it",
+    "web/action" => "loaded with the dashboard",
+    "web/application" => "loaded with the dashboard",
+    "web/csrf_protection" => "loaded with the dashboard",
+    "web/helpers" => "loaded with the dashboard",
+    "web/paginator" => "loaded with the dashboard",
+    "web/route" => "loaded with the dashboard",
+    "web/router" => "loaded with the dashboard",
+    "web/statistics" => "loaded with the dashboard"
   }.freeze
 
   test "requiring the gem defines everything a runtime role reaches for" do

--- a/test/integration/web_charts_test.rb
+++ b/test/integration/web_charts_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "web_test_helper"
+
+class WebChartsTest < WebTestCase
+  teardown do
+    SolidObjects::Web.reset!
+  end
+
+  test "loads the chart library from the configured source with an integrity hash" do
+    response = get("/")
+
+    assert_match(%r{src="https://cdn\.jsdelivr\.net/npm/chart\.js@[\d.]+/dist/chart\.umd\.min\.js"}, response.body)
+    assert_match(/integrity="sha384-[A-Za-z0-9+\/=]+"/, response.body)
+    assert_match(/crossorigin="anonymous"/, response.body)
+  end
+
+  test "names the chart host in the content security policy and nothing wider" do
+    policy = get("/").headers["content-security-policy"]
+    script_source = policy[/script-src ([^;]+)/, 1]
+
+    assert_includes script_source, "https://cdn.jsdelivr.net"
+    refute_includes script_source, "'unsafe-inline'"
+    refute_includes script_source, "'unsafe-eval'"
+    # The host, not the scheme. A bare `https:` source would admit every host
+    # that serves over TLS.
+    refute_match(/(\A|\s)https:(\s|\z)/, script_source)
+  end
+
+  test "renders the instance counts each chart draws" do
+    2.times { |index| create_instance(actor_type: "web-counter", actor_id: "counter-#{index}") }
+    create_instance(actor_type: "web-room", actor_id: "room")
+
+    values = chart_values(get("/").body, "instances_by_type")
+
+    assert_equal({ "web-counter" => 2, "web-room" => 1 }, values)
+  end
+
+  test "renders mailbox and outbox charts from the same counts the page shows" do
+    instance = create_instance
+    mark_ready(create_message(instance))
+    body = get("/").body
+
+    assert_equal({ "Ready" => 1, "Due" => 1, "Claimed" => 0 }, chart_values(body, "mailbox_depth"))
+
+    statuses = chart_values(body, "work_by_status")
+
+    assert_equal 0, statuses.dig("Effects", "pending")
+    assert_equal 0, statuses.dig("Broadcasts", "delivered")
+    assert_equal 0, statuses.dig("Reminders", "scheduled")
+  end
+
+  test "escapes an actor type that would otherwise close the data attribute" do
+    create_instance(actor_type: "web-'onerror=alert(1)", actor_id: "one")
+    body = get("/").body
+
+    # The quote is what matters: escaped, the payload stays one attribute
+    # value; raw, it would close the attribute and start a new one.
+    assert_includes body, "&#39;onerror"
+    refute_includes body, "'onerror"
+    assert_equal({ "web-'onerror=alert(1)" => 1 }, chart_values(body, "instances_by_type"))
+  end
+
+  test "serves no chart library and names no external host when charts are disabled" do
+    SolidObjects::Web.chart_library_url = nil
+
+    response = get("/")
+
+    refute_match(/jsdelivr/, response.body)
+    refute_match(/data-chart=/, response.body)
+    refute_includes response.headers["content-security-policy"], "jsdelivr"
+  end
+
+  test "accepts a self hosted copy without widening the policy" do
+    SolidObjects::Web.chart_library_url = "/javascripts/chart.js"
+    SolidObjects::Web.chart_library_integrity = nil
+
+    response = get("/")
+    script_source = response.headers["content-security-policy"][/script-src ([^;]+)/, 1]
+
+    assert_match(%r{src="/solid_objects/javascripts/chart\.js"}, response.body)
+    refute_match(/integrity=/, response.body)
+    refute_match(%r{https?://}, script_source)
+  end
+
+  test "leaves list pages without a chart library" do
+    refute_match(/jsdelivr/, get("/instances").body)
+  end
+
+  # Chart.js sizes a responsive canvas from its parent. Left in a panel whose
+  # own height follows its children, each redraw measures a box that the last
+  # redraw resized, and the chart creeps larger on every poll. The library
+  # requires a dedicated container with a height of its own.
+  test "puts every canvas in a container with a height that does not follow it" do
+    body = get("/").body
+
+    canvases = body.scan("<canvas data-chart=").length
+    framed = body.scan(%r{<div class="chart-frame"><canvas data-chart=}).length
+
+    assert_equal 3, canvases
+    assert_equal canvases, framed, "every canvas needs its own sized container"
+  end
+
+  test "sizes the chart container in the stylesheet and takes the canvas out of flow" do
+    stylesheet = File.read(File.expand_path("../../web/assets/stylesheets/application.css", __dir__))
+    frame = stylesheet[/\.chart-frame \{([^}]*)\}/, 1].to_s
+    canvas = stylesheet[/\.chart-frame canvas \{([^}]*)\}/, 1].to_s
+
+    assert_match(/position:\s*relative/, frame)
+    assert_match(/height:\s*\d+px/, frame)
+    # Out of flow, the canvas cannot change the height of the box the library
+    # measures, so no redraw can feed the next one.
+    assert_match(/position:\s*absolute/, canvas)
+    refute_match(/canvas\s*\{[^}]*height[^}]*!important/, stylesheet,
+      "forcing the canvas height fights the library instead of sizing its container")
+  end
+
+  private
+
+  def chart_values(body, name)
+    raw = body[/data-chart="#{name}" data-chart-values='([^']*)'/, 1]
+    assert raw, "no chart named #{name} in the page"
+
+    JSON.parse(CGI.unescapeHTML(raw))
+  end
+end

--- a/test/integration/web_dead_letters_test.rb
+++ b/test/integration/web_dead_letters_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "web_test_helper"
+
+class WebDeadLettersTest < WebTestCase
+  class PoisonActor < SolidObjects::Actor
+    actor_type "web-dead-letter-poison"
+
+    class << self
+      attr_accessor :fail
+    end
+
+    def run
+      raise "poison message" if self.class.fail
+    end
+  end
+
+  setup do
+    PoisonActor.fail = true
+    SolidObjects.configuration.max_attempts = 1
+    SolidObjects.configuration.retry_delay = ->(_attempt) { 0 }
+    @dead_letter = create_dead_letter
+  end
+
+  test "lists a dead letter with its exception" do
+    response = get("/dead_letters")
+
+    assert_equal 200, response.status
+    assert_match(/web-dead-letter-poison/, response.body)
+    assert_match(/RuntimeError/, response.body)
+  end
+
+  test "shows a dead letter with its backtrace" do
+    response = get("/dead_letters/#{@dead_letter.id}")
+
+    assert_equal 200, response.status
+    assert_match(/poison message/, response.body)
+    assert_match(/web_dead_letters_test/, response.body)
+  end
+
+  test "retries a dead letter through the authorized manager" do
+    PoisonActor.fail = false
+
+    response = post("/dead_letters/#{@dead_letter.id}/retry")
+
+    assert_equal 302, response.status
+    assert @dead_letter.reload.retried_message_id
+  end
+
+  test "retrying twice reuses the first retry message" do
+    PoisonActor.fail = false
+
+    post("/dead_letters/#{@dead_letter.id}/retry")
+    first_message_id = @dead_letter.reload.retried_message_id
+    post("/dead_letters/#{@dead_letter.id}/retry")
+
+    assert_equal first_message_id, @dead_letter.reload.retried_message_id
+  end
+
+  # A class can be deleted while its dead letters outlive it. The operator who
+  # presses Retry has to be told why nothing happened, rather than shown a bare
+  # 500 from an exception that reached the Rack handler.
+  test "reports a retry the runtime refuses rather than failing the page" do
+    orphan = create_orphan_dead_letter
+
+    response = post("/dead_letters/#{orphan.id}/retry")
+
+    assert_equal 422, response.status
+    assert_match(/web-retired-actor/, response.body)
+    assert_match(/unknown actor type/, response.body)
+    assert_nil orphan.reload.retried_message_id
+  end
+
+  test "refuses a retry the administration policy denies" do
+    SolidObjects.configuration.authorize_administration = lambda do |action:, **|
+      action != "retry"
+    end
+
+    response = post("/dead_letters/#{@dead_letter.id}/retry")
+
+    assert_equal 403, response.status
+    assert_nil @dead_letter.reload.retried_message_id
+  end
+
+  private
+
+  def create_orphan_dead_letter
+    instance = create_instance(actor_type: "web-retired-actor", actor_id: "gone")
+    message = create_message(instance, operation: "checkout")
+    now = SolidObjects.database_adapter.database_now
+    SolidObjects::DeadLetter.create!(
+      message:,
+      instance:,
+      actor_type: instance.actor_type,
+      actor_id: instance.actor_id,
+      operation: message.operation,
+      arguments: message.arguments,
+      attempts: 5,
+      exception_class: "RuntimeError",
+      exception_message: "gave up",
+      backtrace: [],
+      first_failed_at: now,
+      last_failed_at: now
+    )
+  end
+
+  def create_dead_letter
+    PoisonActor.ref("one").async.run
+    worker = SolidObjects::Worker.new
+    worker.run_until_idle
+    SolidObjects::DeadLetter.first
+  ensure
+    worker&.stop
+  end
+end

--- a/test/integration/web_extension_test.rb
+++ b/test/integration/web_extension_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "web_test_helper"
+
+class WebExtensionTest < WebTestCase
+  EXTENSION = Module.new do
+    # @rbs (untyped) -> void
+    def self.registered(application)
+      application.get "/probe", policy: { action: "index", resource: "probe" } do
+        erb(:_probe)
+      end
+    end
+  end
+
+  VIEWS = File.expand_path("../fixtures/web_extension", __dir__)
+
+  setup do
+    SolidObjects::Web.register(EXTENSION, tab: "Probe", path: "/probe", views: VIEWS)
+  end
+
+  teardown do
+    SolidObjects::Web.reset!
+  end
+
+  test "serves a page the extension declared" do
+    response = get("/probe")
+
+    assert_equal 200, response.status
+    assert_match(/probe page/, response.body)
+  end
+
+  test "adds the extension tab to every page" do
+    assert_match(%r{href="/solid_objects/probe"}, get("/").body)
+  end
+
+  test "applies the administration policy to an extension route" do
+    SolidObjects.configuration.authorize_administration = lambda do |resource:, **|
+      resource != "probe"
+    end
+
+    assert_equal 403, get("/probe").status
+  end
+
+  test "prefers an extension view directory over the packaged one" do
+    assert_match(/replaced summary/, get("/probe").body)
+  end
+
+  # Registered after the dashboard has already served a request, because the
+  # built middleware stack is memoized and a late `use` would otherwise be
+  # silently ignored.
+  test "runs middleware an application put in front of the dashboard" do
+    get("/")
+    SolidObjects::Web.use(StampMiddleware)
+
+    assert_equal "stamped", get("/").headers["x-probe"]
+  end
+
+  class StampMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      [ status, headers.merge("x-probe" => "stamped"), body ]
+    end
+  end
+end

--- a/test/integration/web_mount_test.rb
+++ b/test/integration/web_mount_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+
+# A Rack application behaves differently under a real Rails router than under a
+# mock environment. The mount supplies SCRIPT_NAME, the Rails session
+# middleware supplies the session CSRF protection needs, and a dashboard nested
+# below the engine mount is only reachable because the engine cascades a path
+# it does not serve. This runs the dashboard where it actually runs.
+class WebMountTest < ActiveSupport::TestCase
+  test "serves the dashboard from a real Rails mount" do
+    assert_equal "403", results.fetch("denied"), "an unauthorized request must not reach a page"
+    assert_equal "200", results.fetch("allowed")
+    assert_equal "true", results.fetch("actor"), "the page must show data read through the mount"
+    assert_equal "true", results.fetch("mounted_link"), "assets must be linked below the mount path"
+    assert_equal "true", results.fetch("session"), "the Rails session must reach the dashboard"
+  end
+
+  test "rejects a forged token and applies a valid one through the Rails session" do
+    assert_equal "403", results.fetch("forged")
+    assert_equal "false", results.fetch("forged_paused"), "a forged token must not change the runtime"
+    assert_equal "302", results.fetch("paused")
+    assert_equal "/solid_objects/dashboard/instances/1", results.fetch("paused_location")
+    assert_equal "true", results.fetch("paused_at")
+  end
+
+  private
+
+  def results
+    @results ||= begin
+      output, error_output, status = Open3.capture3(
+        Gem.ruby,
+        File.expand_path("../dummy/web_mount_check.rb", __dir__)
+      )
+      assert status.success?, error_output
+      output.split("\n").to_h { |line| line.split("=", 2) }
+    end
+  end
+end

--- a/test/integration/web_test.rb
+++ b/test/integration/web_test.rb
@@ -1,0 +1,280 @@
+# frozen_string_literal: true
+
+require "web_test_helper"
+
+class WebTest < WebTestCase
+  test "denies every page when administration is not authorized" do
+    SolidObjects.configuration.authorize_administration = ->(**) { false }
+
+    %w[/ /instances /mailbox /reminders /effects /broadcasts /dead_letters /processes /stats].each do |path|
+      response = get(path)
+
+      assert_equal 403, response.status, "#{path} must deny by default"
+    end
+  end
+
+  test "denies with the default configuration, which authorizes nothing" do
+    SolidObjects.reset!
+
+    assert_equal 403, get("/").status
+  end
+
+  test "passes the route policy and the request to the authorization block" do
+    instance = create_instance
+    seen = []
+    SolidObjects.configuration.authorize_administration = lambda do |action:, resource:, resource_id:, authorization_context:|
+      seen << [ action, resource, resource_id, authorization_context.request.path ]
+      true
+    end
+
+    get("/instances/#{instance.id}")
+
+    assert_equal [ [ "show", "instances", instance.id.to_s, "/solid_objects/instances/#{instance.id}" ] ], seen
+  end
+
+  test "renders the dashboard with runtime counts" do
+    instance = create_instance
+    mark_ready(create_message(instance))
+
+    response = get("/")
+
+    assert_equal 200, response.status
+    assert_match(/Solid Objects/, response.body)
+    assert_match(/Instances/, response.body)
+    assert_match(/Ready/, response.body)
+  end
+
+  test "reports the same counts as JSON" do
+    instance = create_instance
+    mark_ready(create_message(instance))
+
+    response = get("/stats")
+    payload = JSON.parse(response.body)
+
+    assert_equal 200, response.status
+    assert_equal "application/json", response.headers["content-type"]
+    assert_equal "private, no-store", response.headers["cache-control"]
+    assert_equal 1, payload.dig("instances", "total")
+    assert_equal 1, payload.dig("mailbox", "ready")
+    assert_equal 0, payload.dig("mailbox", "claimed")
+  end
+
+  test "answers a HEAD request without rendering a page" do
+    response = request("/", method: "HEAD", params: {})
+
+    assert_equal 200, response.status
+    assert_empty response.body
+  end
+
+  test "lists instances and links to each one" do
+    instance = create_instance(actor_type: "web-counter", actor_id: "alpha")
+
+    response = get("/instances")
+
+    assert_equal 200, response.status
+    assert_match(/web-counter/, response.body)
+    assert_match(/alpha/, response.body)
+    assert_match(%r{/solid_objects/instances/#{instance.id}}, response.body)
+  end
+
+  test "filters instances by actor type and by actor id substring" do
+    create_instance(actor_type: "web-counter", actor_id: "alpha")
+    create_instance(actor_type: "web-room", actor_id: "beta")
+
+    typed = get("/instances", "actor_type" => "web-room")
+
+    assert_match(/beta/, typed.body)
+    refute_match(/alpha/, typed.body)
+
+    named = get("/instances", "actor_id" => "alph")
+
+    assert_match(/alpha/, named.body)
+    refute_match(/beta/, named.body)
+  end
+
+  test "pages the instance list" do
+    3.times { |index| create_instance(actor_id: "page-#{index}") }
+
+    response = get("/instances", "per_page" => "2")
+
+    assert_equal 2, response.body.scan("data-instance-row").length
+    assert_match(/page=2/, response.body)
+  end
+
+  test "shows an instance with its state and mailbox" do
+    instance = create_instance(state: { "value" => 41 })
+    mark_ready(create_message(instance, operation: "increment"))
+
+    response = get("/instances/#{instance.id}")
+
+    assert_equal 200, response.status
+    assert_match(/41/, response.body)
+    assert_match(/increment/, response.body)
+  end
+
+  test "returns 404 for an unknown instance" do
+    assert_equal 404, get("/instances/999999").status
+  end
+
+  test "renders an instance whose actor type is no longer registered" do
+    instance = create_instance(actor_type: "web-retired-actor")
+
+    response = get("/instances/#{instance.id}")
+
+    assert_equal 200, response.status
+    assert_match(/web-retired-actor/, response.body)
+  end
+
+  test "escapes actor identifiers in rendered pages" do
+    create_instance(actor_id: "<script>alert(1)</script>")
+
+    response = get("/instances")
+
+    refute_match(%r{<script>alert}, response.body)
+    assert_match(/&lt;script&gt;alert/, response.body)
+  end
+
+  test "pauses and resumes an instance" do
+    instance = create_instance
+
+    paused = post("/instances/#{instance.id}/pause")
+
+    assert_equal 302, paused.status
+    assert instance.reload.paused_at
+
+    resumed = post("/instances/#{instance.id}/resume")
+
+    assert_equal 302, resumed.status
+    assert_nil instance.reload.paused_at
+  end
+
+  test "rejects a state changing request without a valid CSRF token" do
+    instance = create_instance
+
+    response = post_without_csrf_token("/instances/#{instance.id}/pause")
+
+    assert_equal 403, response.status
+    assert_nil instance.reload.paused_at
+  end
+
+  test "lists ready and claimed mailbox messages" do
+    instance = create_instance
+    mark_ready(create_message(instance, operation: "increment"))
+
+    response = get("/mailbox")
+
+    assert_equal 200, response.status
+    assert_match(/increment/, response.body)
+    assert_match(/ready/, response.body)
+  end
+
+  test "shows a single message with its arguments" do
+    instance = create_instance
+    message = create_message(instance, operation: "increment")
+
+    response = get("/messages/#{message.id}")
+
+    assert_equal 200, response.status
+    assert_match(/increment/, response.body)
+    assert_match(/amount/, response.body)
+  end
+
+  test "lists reminders, effects, broadcasts and processes" do
+    instance = create_instance
+    message = create_message(instance)
+    now = SolidObjects.database_adapter.database_now
+    SolidObjects::Reminder.create!(
+      instance:,
+      actor_type: instance.actor_type,
+      actor_id: instance.actor_id,
+      name: "web-reminder",
+      operation: "tick",
+      arguments: {},
+      next_run_at: now
+    )
+    SolidObjects::Effect.create!(
+      instance:,
+      message:,
+      effect_id: SecureRandom.uuid,
+      name: "web-effect",
+      arguments: {},
+      max_attempts: 5,
+      available_at: now
+    )
+    SolidObjects::Broadcast.create!(
+      instance:,
+      message:,
+      broadcast_id: SecureRandom.uuid,
+      observable_name: "web-observable",
+      value: {},
+      state_version: 1,
+      activation_generation: 1,
+      available_at: now
+    )
+    SolidObjects::Process.create!(
+      id: SecureRandom.uuid,
+      kind: "worker",
+      hostname: "web-host",
+      pid: 4321,
+      started_at: now,
+      last_heartbeat_at: now,
+      metadata: {}
+    )
+
+    assert_match(/web-reminder/, get("/reminders").body)
+    assert_match(/web-effect/, get("/effects").body)
+    assert_match(/web-observable/, get("/broadcasts").body)
+    assert_match(/web-host/, get("/processes").body)
+  end
+
+  test "filters a status backed list" do
+    instance = create_instance
+    message = create_message(instance)
+    now = SolidObjects.database_adapter.database_now
+    SolidObjects::Effect.create!(
+      instance:,
+      message:,
+      effect_id: SecureRandom.uuid,
+      name: "web-pending-effect",
+      arguments: {},
+      max_attempts: 5,
+      available_at: now
+    )
+
+    assert_match(/web-pending-effect/, get("/effects", "status" => "pending").body)
+    refute_match(/web-pending-effect/, get("/effects", "status" => "dead").body)
+  end
+
+  test "serves the stylesheet and the javascript from the mount" do
+    stylesheet = get("/stylesheets/application.css")
+    javascript = get("/javascripts/application.js")
+
+    assert_equal 200, stylesheet.status
+    assert_equal 200, javascript.status
+  end
+
+  test "builds asset and page links below the mount path" do
+    response = get("/")
+
+    assert_match(%r{href="/solid_objects/stylesheets/application.css"}, response.body)
+    assert_match(%r{href="/solid_objects/instances"}, response.body)
+  end
+
+  test "sends a nonce backed content security policy" do
+    response = get("/")
+    nonce = response.body[/nonce="([^"]+)"/, 1]
+
+    assert nonce
+    assert_includes response.headers["content-security-policy"], "'nonce-#{nonce}'"
+    refute_includes response.headers["content-security-policy"],
+      SolidObjects::Web::Application::SCRIPT_PLACEHOLDER
+    assert_equal "nosniff", response.headers["x-content-type-options"]
+  end
+
+  test "returns 404 with a cascade header for an unknown path" do
+    response = get("/nowhere")
+
+    assert_equal 404, response.status
+    assert_equal "pass", response.headers["x-cascade"]
+  end
+end

--- a/test/integration/web_test.rb
+++ b/test/integration/web_test.rb
@@ -157,6 +157,45 @@ class WebTest < WebTestCase
     assert_nil instance.reload.paused_at
   end
 
+  test "rejects a token that was not derived from this session" do
+    instance = create_instance
+    get("/")
+
+    response = request(
+      "/instances/#{instance.id}/pause",
+      method: "POST",
+      params: { "authenticity_token" => SecureRandom.base64(32) }
+    )
+
+    assert_equal 403, response.status
+    assert_nil instance.reload.paused_at
+  end
+
+  # The dead-letter list renders one Retry form per row, and a browser keeps
+  # pages open in other tabs. Spending the session secret on the first
+  # submission would answer 403 to every other form the same page rendered.
+  test "accepts every form a page rendered, not only the first" do
+    instance = create_instance
+    token = rendered_token("/instances/#{instance.id}")
+
+    paused = submit("/instances/#{instance.id}/pause", token)
+    resumed = submit("/instances/#{instance.id}/resume", token)
+
+    assert_equal 302, paused.status
+    assert_equal 302, resumed.status, "a second form from the same page must still be accepted"
+    assert_nil instance.reload.paused_at
+  end
+
+  test "issues a differently masked token on each request" do
+    instance = create_instance
+    first = rendered_token("/instances/#{instance.id}")
+    second = rendered_token("/instances/#{instance.id}")
+
+    refute_equal first, second, "an unchanging token on the wire is what masking prevents"
+    assert_equal 302, submit("/instances/#{instance.id}/pause", first).status
+    assert_equal 302, submit("/instances/#{instance.id}/resume", second).status
+  end
+
   test "lists ready and claimed mailbox messages" do
     instance = create_instance
     mark_ready(create_message(instance, operation: "increment"))

--- a/test/javascript/charts.test.mjs
+++ b/test/javascript/charts.test.mjs
@@ -1,0 +1,186 @@
+import { strict as assert } from "node:assert"
+import { readFileSync } from "node:fs"
+import { test } from "node:test"
+import { JSDOM } from "jsdom"
+
+const SOURCE = readFileSync(
+  new URL("../../web/assets/javascripts/charts.js", import.meta.url),
+  "utf8"
+)
+
+const INSTANCES = { ShoppingCart: 6, ChatRoom: 4 }
+const MAILBOX = { Ready: 12, Due: 9, Claimed: 3 }
+const WORK = {
+  Effects: { pending: 2, processing: 1, completed: 5, dead: 1 },
+  Broadcasts: { pending: 3, processing: 0, delivered: 4, dead: 0 },
+  Reminders: { scheduled: 7, paused: 1, completed: 2 }
+}
+
+function canvas(name, values) {
+  return `<canvas data-chart="${name}" data-chart-values='${JSON.stringify(values)}'></canvas>`
+}
+
+// A stand-in for Chart.js that records what the page asked it to draw. The
+// real library needs a 2d canvas context jsdom does not provide, and what is
+// worth asserting is the data and the axis, not the pixels.
+function openCharts(markup) {
+  const dom = new JSDOM(`<!doctype html><html><body>${markup}</body></html>`, {
+    url: "https://example.test/solid_objects/",
+    runScripts: "outside-only"
+  })
+
+  const drawn = []
+  dom.window.Chart = function (element, configuration) {
+    this.data = configuration.data
+    this.options = configuration.options
+    this.type = configuration.type
+    this.updates = 0
+    this.update = () => {
+      this.updates += 1
+    }
+    drawn.push(this)
+  }
+
+  dom.window.eval(SOURCE)
+
+  return { dom, drawn, close: () => dom.window.close() }
+}
+
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function chartOf(drawn, label) {
+  return drawn.find((chart) => chart.data.labels.includes(label))
+}
+
+// Arrays built inside the jsdom realm have a different Array.prototype, so
+// deepStrictEqual rejects them as not reference-equal. Copying into this
+// realm compares the values, which is what these tests are about.
+function plain(values) {
+  return Array.from(values)
+}
+
+test("draws each canvas from the data the page rendered", async () => {
+  const charts = openCharts(
+    canvas("instances_by_type", INSTANCES) +
+      canvas("mailbox_depth", MAILBOX) +
+      canvas("work_by_status", WORK)
+  )
+  try {
+    await settle()
+
+    assert.equal(charts.drawn.length, 3)
+
+    const instances = chartOf(charts.drawn, "ShoppingCart")
+    assert.deepEqual(plain(instances.data.labels), ["ShoppingCart", "ChatRoom"])
+    assert.deepEqual(plain(instances.data.datasets[0].data), [6, 4])
+    assert.equal(instances.options.indexAxis, "y")
+
+    const mailbox = chartOf(charts.drawn, "Ready")
+    assert.deepEqual(plain(mailbox.data.datasets[0].data), [12, 9, 3])
+    assert.equal(mailbox.options.indexAxis, undefined)
+  } finally {
+    charts.close()
+  }
+})
+
+test("gives a subsystem a zero for a status it does not have", async () => {
+  const charts = openCharts(canvas("work_by_status", WORK))
+  try {
+    await settle()
+
+    const work = charts.drawn[0]
+    const scheduled = work.data.datasets.find((set) => set.label === "scheduled")
+    const delivered = work.data.datasets.find((set) => set.label === "delivered")
+
+    assert.deepEqual(plain(work.data.labels), ["Effects", "Broadcasts", "Reminders"])
+    // Only reminders are scheduled; only broadcasts are delivered.
+    assert.deepEqual(plain(scheduled.data), [0, 0, 7])
+    assert.deepEqual(plain(delivered.data), [0, 4, 0])
+    assert.equal(work.options.scales.x.stacked, true)
+  } finally {
+    charts.close()
+  }
+})
+
+test("redraws the polled charts when the poller reports new totals", async () => {
+  const charts = openCharts(
+    canvas("instances_by_type", INSTANCES) +
+      canvas("mailbox_depth", MAILBOX) +
+      canvas("work_by_status", WORK)
+  )
+  try {
+    await settle()
+    const instances = chartOf(charts.drawn, "ShoppingCart")
+    const mailbox = chartOf(charts.drawn, "Ready")
+    const work = chartOf(charts.drawn, "Effects")
+
+    charts.dom.window.document.dispatchEvent(
+      new charts.dom.window.CustomEvent("solid-objects:statistics", {
+        detail: {
+          mailbox: { ready: 1, due: 0, claimed: 5 },
+          effects: { pending: 9, processing: 0, completed: 0, dead: 0 },
+          broadcasts: { pending: 0, processing: 0, delivered: 0, dead: 2 },
+          reminders: { scheduled: 0, paused: 0, completed: 0, due: 4 }
+        }
+      })
+    )
+
+    assert.deepEqual(plain(mailbox.data.datasets[0].data), [1, 0, 5])
+    assert.equal(
+      work.data.datasets.find((set) => set.label === "pending").data[0],
+      9
+    )
+    assert.equal(mailbox.updates, 1)
+    // /stats carries no instance counts, so that chart is left alone.
+    assert.equal(instances.updates, 0)
+    assert.deepEqual(plain(instances.data.datasets[0].data), [6, 4])
+  } finally {
+    charts.close()
+  }
+})
+
+test("leaves the drawn charts alone when a payload is missing a section", async () => {
+  const charts = openCharts(canvas("mailbox_depth", MAILBOX))
+  try {
+    await settle()
+    const mailbox = charts.drawn[0]
+
+    charts.dom.window.document.dispatchEvent(
+      new charts.dom.window.CustomEvent("solid-objects:statistics", { detail: {} })
+    )
+
+    assert.deepEqual(plain(mailbox.data.datasets[0].data), [12, 9, 3])
+  } finally {
+    charts.close()
+  }
+})
+
+test("draws nothing when the chart library did not load", async () => {
+  const dom = new JSDOM(
+    `<!doctype html><html><body>${canvas("mailbox_depth", MAILBOX)}</body></html>`,
+    { url: "https://example.test/", runScripts: "outside-only" }
+  )
+  try {
+    dom.window.eval(SOURCE)
+    await settle()
+
+    assert.equal(dom.window.document.querySelectorAll("[data-chart]").length, 1)
+  } finally {
+    dom.window.close()
+  }
+})
+
+test("skips a canvas whose data attribute is not valid JSON", async () => {
+  const charts = openCharts(
+    `<canvas data-chart="mailbox_depth" data-chart-values='not json'></canvas>`
+  )
+  try {
+    await settle()
+
+    assert.equal(charts.drawn.length, 0)
+  } finally {
+    charts.close()
+  }
+})

--- a/test/javascript/dashboard.test.mjs
+++ b/test/javascript/dashboard.test.mjs
@@ -1,0 +1,166 @@
+import { strict as assert } from "node:assert"
+import { readFileSync } from "node:fs"
+import { test } from "node:test"
+import { JSDOM } from "jsdom"
+
+const SOURCE = readFileSync(
+  new URL("../../web/assets/javascripts/application.js", import.meta.url),
+  "utf8"
+)
+
+// The same numbers SolidObjects::Web::Helpers renders on the server. The
+// polled cell sits beside server-rendered ones, so the two formatters have to
+// agree; test/unit/web_helpers_test.rb asserts the Ruby side of this table.
+const DURATIONS = [
+  { value: 0, rendered: "0.000 s" },
+  { value: 4.25, rendered: "4.250 s" },
+  { value: 59.999, rendered: "59.999 s" },
+  { value: 60, rendered: "1 min 0 s" },
+  { value: 511.892, rendered: "8 min 32 s" }
+]
+
+const BODY = `<body data-stats-path="/stats">
+  <button data-poll-toggle aria-pressed="false">Live</button>
+  <span data-statistic="instances.total">0</span>
+  <span data-statistic="mailbox.latency" data-format="duration">0.000 s</span>
+  <span data-statistic="missing.path">untouched</span>
+</body>`
+
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+// The window owns the poll interval, so a suite that leaves one open holds the
+// Node event loop and the whole run hangs rather than fails.
+//
+// Async because the tag is deferred: the script binds the toggle on
+// DOMContentLoaded, which jsdom fires a tick after the document is built. A
+// click issued before that tick lands on nothing.
+async function openDashboard(payload, { failing = false } = {}) {
+  const dom = new JSDOM(`<!doctype html><html>${BODY}</html>`, {
+    url: "https://example.test/solid_objects/",
+    runScripts: "outside-only"
+  })
+
+  const requests = []
+  dom.window.fetch = (path, options) => {
+    requests.push({ path, options })
+    if (failing) return Promise.reject(new Error("offline"))
+
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(payload) })
+  }
+  dom.window.eval(SOURCE)
+  await settle()
+
+  return {
+    dom,
+    requests,
+    toggle: dom.window.document.querySelector("[data-poll-toggle]"),
+    cell: (name) => dom.window.document.querySelector(`[data-statistic="${name}"]`),
+    close: () => dom.window.close()
+  }
+}
+
+test("polls nothing until the toggle is pressed", async () => {
+  const dashboard = await openDashboard({ instances: { total: 5 } })
+  try {
+    await settle()
+
+    assert.equal(dashboard.requests.length, 0)
+    assert.equal(dashboard.cell("instances.total").textContent, "0")
+  } finally {
+    dashboard.close()
+  }
+})
+
+test("polls the stats path once per press and updates cells", async () => {
+  const dashboard = await openDashboard({
+    instances: { total: 1234567 },
+    mailbox: { latency: 511.892 }
+  })
+  try {
+    dashboard.toggle.click()
+    await settle()
+
+    assert.equal(dashboard.requests.length, 1)
+    assert.equal(dashboard.requests[0].path, "/stats")
+    assert.equal(dashboard.requests[0].options.credentials, "same-origin")
+    assert.equal(dashboard.toggle.getAttribute("aria-pressed"), "true")
+    assert.equal(dashboard.cell("instances.total").textContent, "1,234,567")
+    assert.equal(dashboard.cell("mailbox.latency").textContent, "8 min 32 s")
+  } finally {
+    dashboard.close()
+  }
+})
+
+test("a cell whose path is absent from the payload keeps its rendered value", async () => {
+  const dashboard = await openDashboard({ instances: { total: 2 } })
+  try {
+    dashboard.toggle.click()
+    await settle()
+
+    assert.equal(dashboard.cell("missing.path").textContent, "untouched")
+    assert.equal(dashboard.cell("mailbox.latency").textContent, "0.000 s")
+  } finally {
+    dashboard.close()
+  }
+})
+
+test("a failed poll leaves the last rendered totals in place", async () => {
+  const dashboard = await openDashboard({ instances: { total: 2 } }, { failing: true })
+  try {
+    dashboard.toggle.click()
+    await settle()
+
+    assert.equal(dashboard.requests.length, 1)
+    assert.equal(dashboard.cell("instances.total").textContent, "0")
+  } finally {
+    dashboard.close()
+  }
+})
+
+test("pressing the toggle again stops polling", async () => {
+  const dashboard = await openDashboard({ instances: { total: 3 } })
+  try {
+    dashboard.toggle.click()
+    await settle()
+    const polled = dashboard.requests.length
+    dashboard.toggle.click()
+    await settle()
+
+    assert.equal(dashboard.toggle.getAttribute("aria-pressed"), "false")
+    assert.equal(dashboard.requests.length, polled)
+  } finally {
+    dashboard.close()
+  }
+})
+
+test("formats a duration the way the server rendered it", async () => {
+  for (const { value, rendered } of DURATIONS) {
+    const dashboard = await openDashboard({ mailbox: { latency: value } })
+    try {
+      dashboard.toggle.click()
+      await settle()
+
+      assert.equal(
+        dashboard.cell("mailbox.latency").textContent,
+        rendered,
+        `${value} must render as ${rendered}`
+      )
+    } finally {
+      dashboard.close()
+    }
+  }
+})
+
+test("formats a count without turning it into a duration", async () => {
+  const dashboard = await openDashboard({ instances: { total: 0 } })
+  try {
+    dashboard.toggle.click()
+    await settle()
+
+    assert.equal(dashboard.cell("instances.total").textContent, "0")
+  } finally {
+    dashboard.close()
+  }
+})

--- a/test/unit/web_helpers_test.rb
+++ b/test/unit/web_helpers_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "solid_objects/web"
+
+class WebHelpersTest < ActiveSupport::TestCase
+  # The Ruby side of the table in test/javascript/dashboard.test.mjs. The
+  # summary bar renders these on the server and the poller rewrites the same
+  # cells in the browser, so a value that formats differently in one place
+  # reads as a different measurement.
+  DURATIONS = {
+    0.0 => "0.000 s",
+    4.25 => "4.250 s",
+    59.999 => "59.999 s",
+    60.0 => "1 min 0 s",
+    511.892 => "8 min 32 s"
+  }.freeze
+
+  COUNTS = {
+    0 => "0",
+    12 => "12",
+    1_234_567 => "1,234,567"
+  }.freeze
+
+  class Subject
+    include SolidObjects::Web::Helpers
+  end
+
+  setup do
+    @helpers = Subject.new
+  end
+
+  test "formats a duration the way the browser poller formats it" do
+    DURATIONS.each do |seconds, rendered|
+      assert_equal rendered, @helpers.duration(seconds), "#{seconds} must render as #{rendered}"
+    end
+  end
+
+  test "formats a count with thousands separators" do
+    COUNTS.each do |value, rendered|
+      assert_equal rendered, @helpers.number(value), "#{value} must render as #{rendered}"
+    end
+  end
+
+  test "renders a missing duration as a dash rather than zero" do
+    assert_equal "&mdash;", @helpers.duration(nil)
+  end
+
+  test "escapes text that came from an application" do
+    assert_equal "&lt;script&gt;", @helpers.h("<script>")
+    assert_equal "&amp;", @helpers.h("&")
+  end
+
+  test "truncates a payload rather than rendering an unbounded one" do
+    truncated = @helpers.truncate("a" * 3_000, 100)
+
+    assert_equal 101, truncated.length
+    assert truncated.end_with?("…")
+  end
+
+  test "renders a JSON payload as escaped text" do
+    rendered = @helpers.json_block({ "name" => "<script>" })
+
+    assert_includes rendered, "&lt;script&gt;"
+    refute_includes rendered, "<script>"
+  end
+
+  test "renders a payload JSON cannot generate rather than raising" do
+    rendered = @helpers.json_block(Object.new)
+
+    assert_includes rendered, "Object"
+  end
+end

--- a/test/unit/web_router_test.rb
+++ b/test/unit/web_router_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "solid_objects/web"
+
+class WebRouterTest < ActiveSupport::TestCase
+  class Routes
+    extend SolidObjects::Web::Router
+
+    get "/", policy: { action: "index", resource: "dashboard" } do
+      "root"
+    end
+
+    get "/instances/:id", policy: { action: "show", resource: "instances" } do
+      "instance #{route_params(:id)}"
+    end
+
+    post "/instances/:id/pause", policy: { action: "pause", resource: "instances" } do
+      "paused"
+    end
+  end
+
+  test "matches a static path" do
+    route = Routes.match("GET", "/")
+
+    assert_equal "/", route.pattern
+  end
+
+  test "matches a named segment and captures it" do
+    route = Routes.match("GET", "/instances/42")
+
+    assert_equal({ id: "42" }, route.capture("/instances/42"))
+  end
+
+  test "separates routes by request method" do
+    assert_nil Routes.match("POST", "/instances/42")
+    assert Routes.match("POST", "/instances/42/pause")
+  end
+
+  test "does not match a named segment across a slash" do
+    assert_nil Routes.match("GET", "/instances/42/pause")
+  end
+
+  test "carries the authorization policy of the matched route" do
+    route = Routes.match("POST", "/instances/42/pause")
+
+    assert_equal "pause", route.policy.fetch(:action)
+    assert_equal "instances", route.policy.fetch(:resource)
+  end
+
+  test "refuses a route declared without an authorization policy" do
+    error = assert_raises(ArgumentError) do
+      Class.new { extend SolidObjects::Web::Router }.get("/open") { "open" }
+    end
+
+    assert_match(/policy/, error.message)
+  end
+end

--- a/test/web_test_helper.rb
+++ b/test/web_test_helper.rb
@@ -45,6 +45,18 @@ class WebTestCase < ActiveSupport::TestCase
     request(path, method: "POST", params:)
   end
 
+  # The masked token a page actually put in its forms, rather than the session
+  # value behind it.
+  # @rbs (String) -> String
+  def rendered_token(path)
+    get(path).body[/name="authenticity_token" value="([^"]+)"/, 1]
+  end
+
+  # @rbs (String, String, ?Hash[String, untyped]) -> Rack::MockResponse
+  def submit(path, token, params = {})
+    request(path, method: "POST", params: params.merge("authenticity_token" => token))
+  end
+
   # @rbs (String, method: String, params: Hash[String, untyped]) -> Rack::MockResponse
   def request(path, method:, params:)
     environment = Rack::MockRequest.env_for(

--- a/test/web_test_helper.rb
+++ b/test/web_test_helper.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "database_test_helper"
+require "rack/mock_request"
+require "solid_objects/web"
+
+# The dashboard is a Rack application rather than an engine controller, so the
+# suite drives it the way a mount does: a real environment through the real
+# middleware stack. Nothing here stubs the router, the session, or the
+# authorization policy.
+class WebTestCase < ActiveSupport::TestCase
+  MOUNT_PATH = "/solid_objects"
+
+  setup do
+    SolidObjects.configuration.authorize_administration = ->(**) { true }
+    @session = {}
+  end
+
+  teardown do
+    SolidObjects::DeadLetter.delete_all
+    SolidObjects::Broadcast.delete_all
+    SolidObjects::Effect.delete_all
+    SolidObjects::Reminder.delete_all
+    SolidObjects::ClaimedMessage.delete_all
+    SolidObjects::ReadyMessage.delete_all
+    SolidObjects::Message.delete_all
+  end
+
+  private
+
+  attr_reader :session
+
+  # @rbs (String, ?Hash[String, untyped]) -> Rack::MockResponse
+  def get(path, params = {})
+    request(path, method: "GET", params:)
+  end
+
+  # @rbs (String, ?Hash[String, untyped]) -> Rack::MockResponse
+  def post(path, params = {})
+    request(path, method: "POST", params: params.merge("authenticity_token" => csrf_token))
+  end
+
+  # @rbs (String, ?Hash[String, untyped]) -> Rack::MockResponse
+  def post_without_csrf_token(path, params = {})
+    request(path, method: "POST", params:)
+  end
+
+  # @rbs (String, method: String, params: Hash[String, untyped]) -> Rack::MockResponse
+  def request(path, method:, params:)
+    environment = Rack::MockRequest.env_for(
+      "http://example.com#{MOUNT_PATH}#{path}",
+      method:,
+      params:
+    )
+    environment["SCRIPT_NAME"] = MOUNT_PATH
+    environment["PATH_INFO"] = path
+    environment["rack.session"] = session
+    status, headers, body = SolidObjects::Web.call(environment)
+    Rack::MockResponse.new(status, headers, body)
+  end
+
+  # The middleware issues a fresh masked token per request, and accepts the
+  # unmasked session value too. Reading the session directly keeps the helper
+  # from parsing HTML for a token every form-driven test needs.
+  # @rbs () -> String
+  def csrf_token
+    get("/") if session[:csrf].nil?
+    session.fetch(:csrf)
+  end
+
+  # @rbs (?actor_type: String, ?actor_id: String, ?state: Hash[String, untyped]) -> SolidObjects::Instance
+  def create_instance(actor_type: "web-counter", actor_id: "one", state: { "value" => 1 })
+    SolidObjects::Instance.create!(actor_type:, actor_id:, state:)
+  end
+
+  # @rbs (SolidObjects::Instance, ?operation: String, ?delivery_mode: String) -> SolidObjects::Message
+  def create_message(instance, operation: "increment", delivery_mode: "async")
+    now = SolidObjects.database_adapter.database_now
+    sequence = instance.next_message_sequence
+    instance.update!(next_message_sequence: sequence + 1)
+    SolidObjects::Message.create!(
+      instance:,
+      actor_type: instance.actor_type,
+      actor_id: instance.actor_id,
+      operation:,
+      delivery_mode:,
+      arguments: { "amount" => 1 },
+      sequence:,
+      max_attempts: 5,
+      request_id: SecureRandom.uuid,
+      enqueued_at: now,
+      available_at: now
+    )
+  end
+
+  # @rbs (SolidObjects::Message) -> SolidObjects::ReadyMessage
+  def mark_ready(message)
+    SolidObjects::ReadyMessage.create!(
+      message:,
+      instance_id: message.instance_id,
+      sequence: message.sequence,
+      available_at: message.available_at,
+      created_at: message.enqueued_at
+    )
+  end
+end

--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -1,0 +1,118 @@
+// Refreshes the summary bar in place. Nothing else on the page polls, because
+// a dashboard that reloads a table an operator is reading is worse than one
+// that shows a stale table with a live total.
+(function () {
+  "use strict";
+
+  var POLL_INTERVAL = 5000;
+  var STORAGE_KEY = "solid-objects-live";
+
+  var timer = null;
+
+  function readPath() {
+    return document.body.getAttribute("data-stats-path");
+  }
+
+  function lookup(payload, path) {
+    return path.split(".").reduce(function (value, key) {
+      return value == null ? null : value[key];
+    }, payload);
+  }
+
+  // Must match SolidObjects::Web::Helpers#number and #duration. A polled cell
+  // sits beside server-rendered ones, and a value that changes shape the
+  // moment polling starts reads as a different measurement.
+  //
+  // The cell declares which one it is. A duration of exactly zero arrives from
+  // JSON as an integer-valued number, so guessing from the value would print
+  // "0" where the server printed "0.000 s".
+  function format(value, kind) {
+    if (typeof value !== "number") return String(value);
+    if (kind !== "duration") return value.toLocaleString("en-US");
+    if (value < 60) return value.toFixed(3) + " s";
+
+    return Math.floor(value / 60) + " min " + Math.round(value % 60) + " s";
+  }
+
+  function apply(payload) {
+    var cells = document.querySelectorAll("[data-statistic]");
+    Array.prototype.forEach.call(cells, function (cell) {
+      var value = lookup(payload, cell.getAttribute("data-statistic"));
+      if (value == null) return;
+
+      var text = format(value, cell.getAttribute("data-format"));
+      if (cell.textContent !== text) cell.textContent = text;
+    });
+  }
+
+  function poll() {
+    var path = readPath();
+    if (!path) return;
+
+    fetch(path, { credentials: "same-origin", headers: { Accept: "application/json" } })
+      .then(function (response) {
+        return response.ok ? response.json() : null;
+      })
+      .then(function (payload) {
+        if (!payload) return;
+
+        apply(payload);
+        // The charts subscribe to this rather than polling on their own, so
+        // one request refreshes every number on the page.
+        document.dispatchEvent(
+          new CustomEvent("solid-objects:statistics", { detail: payload })
+        );
+      })
+      .catch(function () {
+        // A failed poll leaves the last rendered totals in place.
+      });
+  }
+
+  function setLive(button, live) {
+    button.setAttribute("aria-pressed", live ? "true" : "false");
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, live ? "on" : "off");
+    } catch (error) {
+      // Storage is unavailable in private windows; the toggle still works.
+    }
+
+    if (timer) {
+      window.clearInterval(timer);
+      timer = null;
+    }
+
+    if (live) {
+      poll();
+      timer = window.setInterval(poll, POLL_INTERVAL);
+    }
+  }
+
+  function stored() {
+    try {
+      return window.localStorage.getItem(STORAGE_KEY) === "on";
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function start() {
+    var button = document.querySelector("[data-poll-toggle]");
+    if (!button) return;
+
+    button.addEventListener("click", function () {
+      setLive(button, button.getAttribute("aria-pressed") !== "true");
+    });
+
+    if (stored()) setLive(button, true);
+  }
+
+  // The tag is deferred, so the document is usually still parsing. A script
+  // evaluated after the document finished would never see the event, and
+  // waiting for one that already fired leaves the toggle inert.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/web/assets/javascripts/charts.js
+++ b/web/assets/javascripts/charts.js
@@ -1,0 +1,190 @@
+// Draws the dashboard charts. Each canvas carries its own data in a
+// data-chart-values attribute, so this file never fetches on load and the page
+// needs no script-src exception for an inline block.
+//
+// Two of the three charts redraw when the Live poller reports new totals. The
+// third counts instances per actor type, which /stats does not carry, so it
+// stays as the page rendered it.
+(function () {
+  "use strict";
+
+  // Every status gets its own colour. Related statuses stay in the same
+  // family, because a legend with two identical swatches reads as a defect
+  // even when the two statuses genuinely mean the same thing.
+  var STATUS_COLORS = {
+    pending: "#d29922",
+    paused: "#e07b39",
+    processing: "#4493f8",
+    scheduled: "#7c72ff",
+    completed: "#3fb950",
+    delivered: "#2ea8a0",
+    dead: "#f85149"
+  };
+
+  var SERIES_COLOR = "#4493f8";
+  var charts = {};
+
+  function palette() {
+    var styles = window.getComputedStyle(document.body);
+    return {
+      text: styles.getPropertyValue("--text-muted").trim() || "#626d7a",
+      grid: styles.getPropertyValue("--border").trim() || "#dfe3e8"
+    };
+  }
+
+  function values(canvas) {
+    try {
+      return JSON.parse(canvas.getAttribute("data-chart-values"));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function baseOptions(colors) {
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: { duration: 200 },
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { ticks: { color: colors.text }, grid: { color: colors.grid } },
+        y: {
+          beginAtZero: true,
+          ticks: { color: colors.text, precision: 0 },
+          grid: { color: colors.grid }
+        }
+      }
+    };
+  }
+
+  function barChart(canvas, data, colors, options) {
+    var labels = Object.keys(data);
+    var settings = baseOptions(colors);
+    if (options && options.horizontal) settings.indexAxis = "y";
+
+    return new window.Chart(canvas, {
+      type: "bar",
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            data: labels.map(function (label) {
+              return data[label];
+            }),
+            backgroundColor: SERIES_COLOR,
+            borderRadius: 4,
+            maxBarThickness: 36
+          }
+        ]
+      },
+      options: settings
+    });
+  }
+
+  // One dataset per status so each row shows only the statuses its subsystem
+  // actually has; a subsystem without a status contributes zero to it.
+  function stackedChart(canvas, data, colors) {
+    var rows = Object.keys(data);
+    var statuses = [];
+    rows.forEach(function (row) {
+      Object.keys(data[row]).forEach(function (status) {
+        if (statuses.indexOf(status) === -1) statuses.push(status);
+      });
+    });
+
+    var settings = baseOptions(colors);
+    settings.indexAxis = "y";
+    settings.plugins.legend = { display: true, labels: { color: colors.text } };
+    settings.scales.x.stacked = true;
+    settings.scales.y.stacked = true;
+
+    return new window.Chart(canvas, {
+      type: "bar",
+      data: {
+        labels: rows,
+        datasets: statuses.map(function (status) {
+          return {
+            label: status,
+            backgroundColor: STATUS_COLORS[status] || SERIES_COLOR,
+            borderRadius: 2,
+            data: rows.map(function (row) {
+              return data[row][status] || 0;
+            })
+          };
+        })
+      },
+      options: settings
+    });
+  }
+
+  function build(canvas) {
+    var name = canvas.getAttribute("data-chart");
+    var data = values(canvas);
+    if (!data) return;
+
+    var colors = palette();
+    if (name === "work_by_status") {
+      charts[name] = stackedChart(canvas, data, colors);
+      return;
+    }
+
+    charts[name] = barChart(canvas, data, colors, {
+      horizontal: name === "instances_by_type"
+    });
+  }
+
+  function replace(chart, data) {
+    chart.data.datasets.forEach(function (dataset) {
+      if (!dataset.label) {
+        dataset.data = chart.data.labels.map(function (label) {
+          return data[label] || 0;
+        });
+        return;
+      }
+
+      dataset.data = chart.data.labels.map(function (row) {
+        return (data[row] || {})[dataset.label] || 0;
+      });
+    });
+    chart.update();
+  }
+
+  function refresh(statistics) {
+    if (charts.mailbox_depth) {
+      replace(charts.mailbox_depth, {
+        Ready: statistics.mailbox.ready,
+        Due: statistics.mailbox.due,
+        Claimed: statistics.mailbox.claimed
+      });
+    }
+
+    if (charts.work_by_status) {
+      replace(charts.work_by_status, {
+        Effects: statistics.effects,
+        Broadcasts: statistics.broadcasts,
+        Reminders: statistics.reminders
+      });
+    }
+  }
+
+  function start() {
+    if (!window.Chart) return;
+
+    var canvases = document.querySelectorAll("[data-chart]");
+    Array.prototype.forEach.call(canvases, build);
+
+    document.addEventListener("solid-objects:statistics", function (event) {
+      try {
+        refresh(event.detail);
+      } catch (error) {
+        // A payload missing a section leaves the drawn chart alone.
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -1,0 +1,527 @@
+:root {
+  color-scheme: light dark;
+
+  --page: #f6f7f9;
+  --surface: #ffffff;
+  --surface-sunken: #f0f2f5;
+  --border: #dfe3e8;
+  --text: #1b1f24;
+  --text-muted: #626d7a;
+  --accent: #1f6feb;
+  --accent-contrast: #ffffff;
+  --danger: #b32d2e;
+  --warning: #9a6700;
+  --success: #1a7f37;
+  --radius: 8px;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page: #0d1117;
+    --surface: #161b22;
+    --surface-sunken: #0b0f14;
+    --border: #2b3138;
+    --text: #e6edf3;
+    --text-muted: #99a3ad;
+    --accent: #4493f8;
+    --accent-contrast: #0d1117;
+    --danger: #f85149;
+    --warning: #d29922;
+    --success: #3fb950;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code,
+pre {
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+/* Navigation */
+
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 0 24px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  flex-wrap: wrap;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 0;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.brand:hover {
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.tab {
+  padding: 14px 10px;
+  color: var(--text-muted);
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+}
+
+.tab:hover {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.tab-current {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+
+.bar-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.environment {
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.poll-toggle {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.poll-toggle[aria-pressed="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast);
+}
+
+/* Layout */
+
+.page {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 1px;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 16px;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.metric:hover {
+  background: var(--surface-sunken);
+  text-decoration: none;
+}
+
+.metric-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.metric-value {
+  font-size: 20px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric-alert .metric-value {
+  color: var(--danger);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 16px;
+}
+
+.charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.chart-wide {
+  grid-column: 1 / -1;
+}
+
+/* Chart.js measures a responsive canvas against its parent and writes the
+   canvas size back. The parent therefore needs a height of its own: sizing the
+   canvas instead leaves the library measuring a box it just resized, and the
+   chart creeps larger on every redraw.
+
+   Taking the canvas out of flow closes that loop for good. However the library
+   sizes it, it cannot change the height of the box being measured. */
+.chart-frame {
+  position: relative;
+  height: 240px;
+  width: 100%;
+}
+
+.chart-frame canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.card,
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 20px;
+}
+
+.card h2,
+.panel h2 {
+  margin: 0 0 12px;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  color: var(--text-muted);
+}
+
+.panel h3 {
+  margin: 20px 0 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.panel-head h2 {
+  margin: 0;
+  font-size: 16px;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.actions form {
+  margin: 0;
+}
+
+.note {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  border-left: 3px solid var(--border);
+  background: var(--surface-sunken);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.note-error {
+  border-left-color: var(--danger);
+  color: var(--danger);
+}
+
+.empty {
+  margin: 0;
+  padding: 20px 0;
+  color: var(--text-muted);
+}
+
+/* Data */
+
+dl {
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+/* Several attributes sit side by side, so each one stacks its label over its
+   value. A label-left value-right row would put one value against the next
+   label and read as a single phrase. */
+.attributes {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 8px 24px;
+  margin: 16px 0;
+}
+
+.attributes > div {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.attributes dd {
+  text-align: left;
+}
+
+dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 6px;
+}
+
+dt {
+  color: var(--text-muted);
+}
+
+dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  word-break: break-word;
+}
+
+/* Card values are counts and durations, and "4 min 44 s" reads wrong when the
+   unit wraps onto its own line. */
+.card dd {
+  white-space: nowrap;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+th,
+td {
+  padding: 8px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+th {
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  font-weight: 600;
+}
+
+tbody tr:hover {
+  background: var(--surface-sunken);
+}
+
+time {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.payload {
+  margin: 0;
+  padding: 12px;
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.status-activated,
+.status-running,
+.status-completed,
+.status-delivered {
+  color: var(--success);
+  border-color: currentColor;
+}
+
+.status-paused,
+.status-draining,
+.status-processing,
+.status-expired {
+  color: var(--warning);
+  border-color: currentColor;
+}
+
+.status-dead {
+  color: var(--danger);
+  border-color: currentColor;
+}
+
+/* Forms */
+
+.filters {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.filter {
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.filter:hover {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.filter-current {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.filters-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.filters-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+input,
+select,
+button {
+  font: inherit;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+button.danger:hover {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.paging {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 16px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.paging-links {
+  display: flex;
+  gap: 12px;
+}

--- a/web/views/_messages.erb
+++ b/web/views/_messages.erb
@@ -1,0 +1,29 @@
+<h3><%= h(locals.fetch(:title)) %></h3>
+<% if locals.fetch(:messages).empty? %>
+  <p class="empty"><%= h(locals.fetch(:empty, "None.")) %></p>
+<% else %>
+  <table>
+    <thead>
+      <tr>
+        <th>Sequence</th>
+        <th>Operation</th>
+        <th>Delivery</th>
+        <th>Attempts</th>
+        <th>Available</th>
+        <th>Completed</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% locals.fetch(:messages).each do |message| %>
+        <tr>
+          <td><a href="<%= h(path_to("/messages/#{message.id}")) %>"><%= number(message.sequence) %></a></td>
+          <td><%= h(message.operation) %></td>
+          <td><%= status_label(message.delivery_mode) %></td>
+          <td><%= number(message.attempt_count) %> / <%= number(message.max_attempts) %></td>
+          <td><%= relative_time(message.available_at) %></td>
+          <td><%= relative_time(message.completed_at) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/web/views/_navigation.erb
+++ b/web/views/_navigation.erb
@@ -1,0 +1,15 @@
+<header class="bar">
+  <a class="brand" href="<%= h(path_to("/")) %>">
+    <span class="brand-mark">SO</span>
+    <span class="brand-name">Solid Objects</span>
+  </a>
+  <nav class="tabs">
+    <% tabs.each do |label, path| %>
+      <a class="tab<%= current_tab?(path) ? " tab-current" : "" %>" href="<%= h(path_to(path)) %>"><%= h(label) %></a>
+    <% end %>
+  </nav>
+  <div class="bar-right">
+    <span class="environment"><%= h(environment_name) %></span>
+    <button type="button" class="poll-toggle" data-poll-toggle aria-pressed="false">Live</button>
+  </div>
+</header>

--- a/web/views/_paging.erb
+++ b/web/views/_paging.erb
@@ -1,0 +1,17 @@
+<nav class="paging" aria-label="Pages">
+  <span class="paging-range">
+    <% if @paginator.total.zero? %>
+      No rows
+    <% else %>
+      <%= number(@paginator.first_record) %>&ndash;<%= number(@paginator.last_record) %> of <%= number(@paginator.total) %>
+    <% end %>
+  </span>
+  <span class="paging-links">
+    <% if @paginator.previous_page %>
+      <a href="<%= page_link("page" => @paginator.previous_page) %>">Previous</a>
+    <% end %>
+    <% if @paginator.next_page %>
+      <a href="<%= page_link("page" => @paginator.next_page) %>">Next</a>
+    <% end %>
+  </span>
+</nav>

--- a/web/views/_status_filter.erb
+++ b/web/views/_status_filter.erb
@@ -1,0 +1,8 @@
+<nav class="filters" aria-label="Status filter">
+  <% if locals.fetch(:all, true) %>
+    <a class="filter<%= locals[:selected].nil? ? " filter-current" : "" %>" href="<%= page_link("status" => nil, "page" => nil) %>">All</a>
+  <% end %>
+  <% locals.fetch(:statuses).each do |status| %>
+    <a class="filter<%= (locals[:selected] == status) ? " filter-current" : "" %>" href="<%= page_link("status" => status, "page" => nil) %>"><%= h(status) %></a>
+  <% end %>
+</nav>

--- a/web/views/_summary.erb
+++ b/web/views/_summary.erb
@@ -1,0 +1,39 @@
+<% summary = statistics.to_h %>
+<section class="summary" aria-label="Runtime totals">
+  <a class="metric" href="<%= h(path_to("/instances")) %>">
+    <span class="metric-label">Instances</span>
+    <span class="metric-value" data-statistic="instances.total"><%= number(summary.dig(:instances, :total)) %></span>
+  </a>
+  <a class="metric" href="<%= h(path_to("/mailbox")) %>">
+    <span class="metric-label">Ready</span>
+    <span class="metric-value" data-statistic="mailbox.ready"><%= number(summary.dig(:mailbox, :ready)) %></span>
+  </a>
+  <a class="metric" href="<%= h(path_to("/mailbox?status=claimed")) %>">
+    <span class="metric-label">Claimed</span>
+    <span class="metric-value" data-statistic="mailbox.claimed"><%= number(summary.dig(:mailbox, :claimed)) %></span>
+  </a>
+  <div class="metric">
+    <span class="metric-label">Mailbox lag</span>
+    <span class="metric-value" data-statistic="mailbox.latency" data-format="duration"><%= duration(summary.dig(:mailbox, :latency)) %></span>
+  </div>
+  <a class="metric" href="<%= h(path_to("/effects?status=pending")) %>">
+    <span class="metric-label">Effects</span>
+    <span class="metric-value" data-statistic="effects.pending"><%= number(summary.dig(:effects, :pending)) %></span>
+  </a>
+  <a class="metric" href="<%= h(path_to("/broadcasts?status=pending")) %>">
+    <span class="metric-label">Broadcasts</span>
+    <span class="metric-value" data-statistic="broadcasts.pending"><%= number(summary.dig(:broadcasts, :pending)) %></span>
+  </a>
+  <a class="metric" href="<%= h(path_to("/reminders?status=scheduled")) %>">
+    <span class="metric-label">Reminders due</span>
+    <span class="metric-value" data-statistic="reminders.due"><%= number(summary.dig(:reminders, :due)) %></span>
+  </a>
+  <a class="metric metric-alert" href="<%= h(path_to("/dead_letters")) %>">
+    <span class="metric-label">Dead letters</span>
+    <span class="metric-value" data-statistic="dead_letters.total"><%= number(summary.dig(:dead_letters, :total)) %></span>
+  </a>
+  <a class="metric" href="<%= h(path_to("/processes?status=running")) %>">
+    <span class="metric-label">Processes</span>
+    <span class="metric-value" data-statistic="processes.running"><%= number(summary.dig(:processes, :running)) %></span>
+  </a>
+</section>

--- a/web/views/broadcasts.erb
+++ b/web/views/broadcasts.erb
@@ -1,0 +1,35 @@
+<section class="panel">
+  <h2>Broadcasts</h2>
+  <%= erb(:_status_filter, statuses: SolidObjects::Web::Statistics::BROADCAST_STATUSES, selected: @status) %>
+
+  <% if @paginator.records.empty? %>
+    <p class="empty">No broadcast matches this filter.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr>
+          <th>Observable</th>
+          <th>Actor</th>
+          <th>Status</th>
+          <th>State version</th>
+          <th>Attempts</th>
+          <th>Delivered</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @paginator.records.each do |broadcast| %>
+          <tr>
+            <td><%= h(broadcast.observable_name) %></td>
+            <td><a href="<%= h(path_to("/instances/#{broadcast.instance_id}")) %>">instance <%= number(broadcast.instance_id) %></a></td>
+            <td><%= status_label(broadcast.status) %></td>
+            <td><%= number(broadcast.state_version) %></td>
+            <td><%= number(broadcast.attempt_count) %></td>
+            <td><%= relative_time(broadcast.delivered_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <%= erb(:_paging) %>
+</section>

--- a/web/views/dashboard.erb
+++ b/web/views/dashboard.erb
@@ -1,0 +1,128 @@
+<% if SolidObjects::Web.charts? %>
+  <section class="charts">
+    <article class="panel chart-panel">
+      <h2>Instances by actor type</h2>
+      <%= chart("instances_by_type", @instances_by_type) %>
+    </article>
+    <article class="panel chart-panel">
+      <h2>Mailbox</h2>
+      <%= chart("mailbox_depth", {
+        "Ready" => @statistics.dig(:mailbox, :ready),
+        "Due" => @statistics.dig(:mailbox, :due),
+        "Claimed" => @statistics.dig(:mailbox, :claimed)
+      }) %>
+    </article>
+    <article class="panel chart-panel chart-wide">
+      <h2>Outboxes and reminders by status</h2>
+      <%= chart("work_by_status", {
+        "Effects" => @statistics.fetch(:effects),
+        "Broadcasts" => @statistics.fetch(:broadcasts),
+        "Reminders" => @statistics.fetch(:reminders).except(:due)
+      }) %>
+    </article>
+  </section>
+<% end %>
+
+<section class="cards">
+  <article class="card">
+    <h2>Instances</h2>
+    <dl>
+      <div><dt>Total</dt><dd><%= number(@statistics.dig(:instances, :total)) %></dd></div>
+      <div><dt>Activated</dt><dd><%= number(@statistics.dig(:instances, :activated)) %></dd></div>
+      <div><dt>Paused</dt><dd><%= number(@statistics.dig(:instances, :paused)) %></dd></div>
+    </dl>
+  </article>
+
+  <article class="card">
+    <h2>Mailbox</h2>
+    <dl>
+      <div><dt>Ready</dt><dd><%= number(@statistics.dig(:mailbox, :ready)) %></dd></div>
+      <div><dt>Due</dt><dd><%= number(@statistics.dig(:mailbox, :due)) %></dd></div>
+      <div><dt>Claimed</dt><dd><%= number(@statistics.dig(:mailbox, :claimed)) %></dd></div>
+      <div><dt>Oldest due</dt><dd><%= duration(@statistics.dig(:mailbox, :latency)) %></dd></div>
+    </dl>
+  </article>
+
+  <article class="card">
+    <h2>Effects</h2>
+    <dl>
+      <% @statistics.fetch(:effects).each do |status, count| %>
+        <div><dt><%= h(status) %></dt><dd><%= number(count) %></dd></div>
+      <% end %>
+    </dl>
+  </article>
+
+  <article class="card">
+    <h2>Broadcasts</h2>
+    <dl>
+      <% @statistics.fetch(:broadcasts).each do |status, count| %>
+        <div><dt><%= h(status) %></dt><dd><%= number(count) %></dd></div>
+      <% end %>
+    </dl>
+  </article>
+
+  <article class="card">
+    <h2>Reminders</h2>
+    <dl>
+      <% @statistics.fetch(:reminders).each do |status, count| %>
+        <div><dt><%= h(status) %></dt><dd><%= number(count) %></dd></div>
+      <% end %>
+    </dl>
+  </article>
+
+  <article class="card">
+    <h2>Processes</h2>
+    <dl>
+      <% @statistics.fetch(:processes).each do |state, count| %>
+        <div><dt><%= h(state) %></dt><dd><%= number(count) %></dd></div>
+      <% end %>
+    </dl>
+  </article>
+</section>
+
+<section class="panel">
+  <h2>Processes</h2>
+  <% if @processes.empty? %>
+    <p class="empty">No process has registered. Start one with <code>solid_objects start</code>.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr><th>Kind</th><th>Host</th><th>PID</th><th>State</th><th>Last heartbeat</th></tr>
+      </thead>
+      <tbody>
+        <% @processes.each do |process_record| %>
+          <tr>
+            <td><%= h(process_record.kind) %></td>
+            <td><%= h(process_record.hostname) %></td>
+            <td><%= h(process_record.pid) %></td>
+            <td><%= status_label(process_record.shutdown_state) %></td>
+            <td><%= relative_time(process_record.last_heartbeat_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>
+
+<section class="panel">
+  <h2>Recent dead letters</h2>
+  <% if @dead_letters.empty? %>
+    <p class="empty">No message has exhausted its attempts.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr><th>Actor</th><th>Operation</th><th>Exception</th><th>Last failed</th></tr>
+      </thead>
+      <tbody>
+        <% @dead_letters.each do |dead_letter| %>
+          <tr>
+            <td><a href="<%= h(path_to("/dead_letters/#{dead_letter.id}")) %>"><%= actor_label(dead_letter) %></a></td>
+            <td><%= h(dead_letter.operation) %></td>
+            <td><%= h(dead_letter.exception_class) %></td>
+            <td><%= relative_time(dead_letter.last_failed_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>

--- a/web/views/dead_letter.erb
+++ b/web/views/dead_letter.erb
@@ -1,0 +1,40 @@
+<section class="panel">
+  <div class="panel-head">
+    <h2><%= h(@dead_letter.operation) %></h2>
+    <div class="actions">
+      <a href="<%= h(path_to("/instances/#{@dead_letter.instance_id}")) %>"><%= actor_label(@dead_letter) %></a>
+      <% if @dead_letter.retried_message_id %>
+        <a href="<%= h(path_to("/messages/#{@dead_letter.retried_message_id}")) %>">Retried</a>
+      <% else %>
+        <%= form_to("/dead_letters/#{@dead_letter.id}/retry") %>
+          <button type="submit">Retry</button>
+        </form>
+      <% end %>
+    </div>
+  </div>
+
+  <% if @error %>
+    <p class="note note-error">The retry was refused. <%= h(@error) %></p>
+  <% end %>
+
+  <p class="note">
+    A retry enqueues the original operation again under an idempotency key, so
+    pressing it twice produces one message rather than two.
+  </p>
+
+  <dl class="attributes">
+    <div><dt>Attempts</dt><dd><%= number(@dead_letter.attempts) %></dd></div>
+    <div><dt>Exception</dt><dd><%= h(@dead_letter.exception_class) %></dd></div>
+    <div><dt>First failed</dt><dd><%= relative_time(@dead_letter.first_failed_at) %></dd></div>
+    <div><dt>Last failed</dt><dd><%= relative_time(@dead_letter.last_failed_at) %></dd></div>
+  </dl>
+
+  <h3>Message</h3>
+  <pre class="payload"><%= h(truncate(@dead_letter.exception_message)) %></pre>
+
+  <h3>Arguments</h3>
+  <%= json_block(@dead_letter.arguments) %>
+
+  <h3>Backtrace</h3>
+  <pre class="payload"><%= h(truncate(Array(@dead_letter.backtrace).join("\n"))) %></pre>
+</section>

--- a/web/views/dead_letters.erb
+++ b/web/views/dead_letters.erb
@@ -1,0 +1,42 @@
+<section class="panel">
+  <h2>Dead letters</h2>
+
+  <% if @paginator.records.empty? %>
+    <p class="empty">No message has exhausted its attempts.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr>
+          <th>Actor</th>
+          <th>Operation</th>
+          <th>Exception</th>
+          <th>Attempts</th>
+          <th>Last failed</th>
+          <th>Retry</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @paginator.records.each do |dead_letter| %>
+          <tr>
+            <td><a href="<%= h(path_to("/dead_letters/#{dead_letter.id}")) %>"><%= actor_label(dead_letter) %></a></td>
+            <td><%= h(dead_letter.operation) %></td>
+            <td><%= h(dead_letter.exception_class) %></td>
+            <td><%= number(dead_letter.attempts) %></td>
+            <td><%= relative_time(dead_letter.last_failed_at) %></td>
+            <td>
+              <% if dead_letter.retried_message_id %>
+                <a href="<%= h(path_to("/messages/#{dead_letter.retried_message_id}")) %>">retried</a>
+              <% else %>
+                <%= form_to("/dead_letters/#{dead_letter.id}/retry") %>
+                  <button type="submit">Retry</button>
+                </form>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <%= erb(:_paging) %>
+</section>

--- a/web/views/effects.erb
+++ b/web/views/effects.erb
@@ -1,0 +1,35 @@
+<section class="panel">
+  <h2>Effects</h2>
+  <%= erb(:_status_filter, statuses: SolidObjects::Web::Statistics::EFFECT_STATUSES, selected: @status) %>
+
+  <% if @paginator.records.empty? %>
+    <p class="empty">No effect matches this filter.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Actor</th>
+          <th>Status</th>
+          <th>Attempts</th>
+          <th>Available</th>
+          <th>Completed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @paginator.records.each do |effect| %>
+          <tr>
+            <td><%= h(effect.name) %></td>
+            <td><a href="<%= h(path_to("/instances/#{effect.instance_id}")) %>">instance <%= number(effect.instance_id) %></a></td>
+            <td><%= status_label(effect.status) %></td>
+            <td><%= number(effect.attempt_count) %> / <%= number(effect.max_attempts) %></td>
+            <td><%= relative_time(effect.available_at) %></td>
+            <td><%= relative_time(effect.completed_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <%= erb(:_paging) %>
+</section>

--- a/web/views/instance.erb
+++ b/web/views/instance.erb
@@ -1,0 +1,139 @@
+<section class="panel">
+  <div class="panel-head">
+    <h2><%= actor_label(@instance) %></h2>
+    <div class="actions">
+      <%= status_label(lease_state(@instance)) %>
+      <% if @instance.paused_at %>
+        <%= form_to("/instances/#{@instance.id}/resume") %>
+          <button type="submit">Resume</button>
+        </form>
+      <% else %>
+        <%= form_to("/instances/#{@instance.id}/pause") %>
+          <button type="submit" class="danger">Pause</button>
+        </form>
+      <% end %>
+    </div>
+  </div>
+
+  <p class="note">
+    A paused instance is not claimed again. A pass already in flight finishes its
+    turn, and a synchronous caller waiting on this instance times out rather than
+    receiving a result.
+  </p>
+
+  <dl class="attributes">
+    <div><dt>State version</dt><dd><%= number(@instance.state_version) %></dd></div>
+    <div><dt>Next sequence</dt><dd><%= number(@instance.next_message_sequence) %></dd></div>
+    <div><dt>Activation generation</dt><dd><%= number(@instance.activation_generation) %></dd></div>
+    <div><dt>Activation owner</dt><dd><%= h(@instance.activation_owner_id || "none") %></dd></div>
+    <div><dt>Lease expires</dt><dd><%= relative_time(@instance.activation_expires_at) %></dd></div>
+    <div><dt>Last used</dt><dd><%= relative_time(@instance.last_used_at) %></dd></div>
+    <div><dt>Last claimed</dt><dd><%= relative_time(@instance.last_claimed_at) %></dd></div>
+    <div><dt>Paused</dt><dd><%= relative_time(@instance.paused_at) %></dd></div>
+  </dl>
+
+  <h3>State</h3>
+  <%= json_block(@instance.state) %>
+</section>
+
+<section class="panel">
+  <h2>Mailbox</h2>
+  <%= erb(:_messages, title: "Ready", messages: @ready_messages, empty: "No message is waiting.") %>
+  <%= erb(:_messages, title: "Claimed", messages: @claimed_messages, empty: "No message is claimed.") %>
+  <%= erb(:_messages, title: "Recent", messages: @recent_messages, empty: "This instance has no message history.") %>
+</section>
+
+<section class="panel">
+  <h2>Reminders</h2>
+  <% if @reminders.empty? %>
+    <p class="empty">No reminder is scheduled.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Operation</th><th>Status</th><th>Next run</th><th>Interval</th></tr>
+      </thead>
+      <tbody>
+        <% @reminders.each do |reminder| %>
+          <tr>
+            <td><%= h(reminder.name) %></td>
+            <td><%= h(reminder.operation) %></td>
+            <td><%= status_label(reminder.status) %></td>
+            <td><%= relative_time(reminder.next_run_at) %></td>
+            <td><%= duration(reminder.interval_seconds) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>
+
+<section class="panel">
+  <h2>Effects</h2>
+  <% if @effects.empty? %>
+    <p class="empty">This instance has emitted no effect.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Status</th><th>Attempts</th><th>Available</th><th>Completed</th></tr>
+      </thead>
+      <tbody>
+        <% @effects.each do |effect| %>
+          <tr>
+            <td><%= h(effect.name) %></td>
+            <td><%= status_label(effect.status) %></td>
+            <td><%= number(effect.attempt_count) %> / <%= number(effect.max_attempts) %></td>
+            <td><%= relative_time(effect.available_at) %></td>
+            <td><%= relative_time(effect.completed_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>
+
+<section class="panel">
+  <h2>Broadcasts</h2>
+  <% if @broadcasts.empty? %>
+    <p class="empty">This instance has broadcast nothing.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr><th>Observable</th><th>Status</th><th>State version</th><th>Attempts</th><th>Delivered</th></tr>
+      </thead>
+      <tbody>
+        <% @broadcasts.each do |broadcast| %>
+          <tr>
+            <td><%= h(broadcast.observable_name) %></td>
+            <td><%= status_label(broadcast.status) %></td>
+            <td><%= number(broadcast.state_version) %></td>
+            <td><%= number(broadcast.attempt_count) %></td>
+            <td><%= relative_time(broadcast.delivered_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>
+
+<section class="panel">
+  <h2>Dead letters</h2>
+  <% if @dead_letters.empty? %>
+    <p class="empty">No message has exhausted its attempts.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr><th>Operation</th><th>Exception</th><th>Attempts</th><th>Last failed</th></tr>
+      </thead>
+      <tbody>
+        <% @dead_letters.each do |dead_letter| %>
+          <tr>
+            <td><a href="<%= h(path_to("/dead_letters/#{dead_letter.id}")) %>"><%= h(dead_letter.operation) %></a></td>
+            <td><%= h(dead_letter.exception_class) %></td>
+            <td><%= number(dead_letter.attempts) %></td>
+            <td><%= relative_time(dead_letter.last_failed_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>

--- a/web/views/instances.erb
+++ b/web/views/instances.erb
@@ -1,0 +1,49 @@
+<section class="panel">
+  <h2>Instances</h2>
+
+  <form class="filters-form" method="get" action="<%= h(path_to("/instances")) %>">
+    <label>
+      Actor type
+      <input type="search" name="actor_type" list="actor-types" value="<%= h(url_params("actor_type")) %>" />
+    </label>
+    <datalist id="actor-types">
+      <% @actor_types.each do |actor_type| %>
+        <option value="<%= h(actor_type) %>"></option>
+      <% end %>
+    </datalist>
+    <label>
+      Actor id contains
+      <input type="search" name="actor_id" value="<%= h(url_params("actor_id")) %>" />
+    </label>
+    <button type="submit">Filter</button>
+  </form>
+
+  <% if @paginator.records.empty? %>
+    <p class="empty">No instance matches this filter.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr>
+          <th>Actor</th>
+          <th>Lease</th>
+          <th>State version</th>
+          <th>Next sequence</th>
+          <th>Last used</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @paginator.records.each do |instance| %>
+          <tr data-instance-row="<%= h(instance.id) %>">
+            <td><%= instance_link(instance) %></td>
+            <td><%= status_label(lease_state(instance)) %></td>
+            <td><%= number(instance.state_version) %></td>
+            <td><%= number(instance.next_message_sequence) %></td>
+            <td><%= relative_time(instance.last_used_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <%= erb(:_paging) %>
+</section>

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Solid Objects</title>
+    <link rel="stylesheet" href="<%= h(path_to("/stylesheets/application.css")) %>" />
+    <script src="<%= h(path_to("/javascripts/application.js")) %>" nonce="<%= h(csp_nonce) %>" defer></script>
+    <% if SolidObjects::Web.charts? && current_tab?("/") %>
+      <script src="<%= h(chart_library_source) %>"<%= chart_library_integrity_attributes %> defer></script>
+      <script src="<%= h(path_to("/javascripts/charts.js")) %>" nonce="<%= h(csp_nonce) %>" defer></script>
+    <% end %>
+  </head>
+  <body data-stats-path="<%= h(path_to("/stats")) %>">
+    <%= erb(:_navigation) %>
+    <main class="page">
+      <%= erb(:_summary) %>
+      <%= locals.fetch(:content) %>
+    </main>
+  </body>
+</html>

--- a/web/views/mailbox.erb
+++ b/web/views/mailbox.erb
@@ -1,0 +1,35 @@
+<section class="panel">
+  <h2>Mailbox</h2>
+  <%= erb(:_status_filter, statuses: SolidObjects::Web::Application::MAILBOX_MEMBERSHIPS, selected: @membership, all: false) %>
+
+  <% if @paginator.records.empty? %>
+    <p class="empty">No message is <%= h(@membership) %>.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr>
+          <th>Actor</th>
+          <th>Sequence</th>
+          <th>Operation</th>
+          <th>Delivery</th>
+          <th>Attempts</th>
+          <th>Available</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @paginator.records.each do |message| %>
+          <tr>
+            <td><a href="<%= h(path_to("/instances/#{message.instance_id}")) %>"><%= actor_label(message) %></a></td>
+            <td><a href="<%= h(path_to("/messages/#{message.id}")) %>"><%= number(message.sequence) %></a></td>
+            <td><%= h(message.operation) %></td>
+            <td><%= status_label(message.delivery_mode) %></td>
+            <td><%= number(message.attempt_count) %> / <%= number(message.max_attempts) %></td>
+            <td><%= relative_time(message.available_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <%= erb(:_paging) %>
+</section>

--- a/web/views/message.erb
+++ b/web/views/message.erb
@@ -1,0 +1,34 @@
+<section class="panel">
+  <div class="panel-head">
+    <h2><%= h(@message.operation) %></h2>
+    <div class="actions">
+      <%= status_label(@message.delivery_mode) %>
+      <a href="<%= h(path_to("/instances/#{@message.instance_id}")) %>"><%= actor_label(@message) %></a>
+    </div>
+  </div>
+
+  <dl class="attributes">
+    <div><dt>Sequence</dt><dd><%= number(@message.sequence) %></dd></div>
+    <div><dt>Attempts</dt><dd><%= number(@message.attempt_count) %> / <%= number(@message.max_attempts) %></dd></div>
+    <div><dt>Request id</dt><dd><%= h(@message.request_id) %></dd></div>
+    <div><dt>Idempotency key</dt><dd><%= h(@message.idempotency_key || "none") %></dd></div>
+    <div><dt>Enqueued</dt><dd><%= relative_time(@message.enqueued_at) %></dd></div>
+    <div><dt>Available</dt><dd><%= relative_time(@message.available_at) %></dd></div>
+    <div><dt>Started</dt><dd><%= relative_time(@message.started_at) %></dd></div>
+    <div><dt>Completed</dt><dd><%= relative_time(@message.completed_at) %></dd></div>
+    <div><dt>Rejected</dt><dd><%= relative_time(@message.rejected_at) %></dd></div>
+    <div><dt>Last failed</dt><dd><%= relative_time(@message.last_failed_at) %></dd></div>
+  </dl>
+
+  <h3>Arguments</h3>
+  <%= json_block(@message.arguments) %>
+
+  <h3>Result</h3>
+  <%= json_block(@message.result) %>
+
+  <h3>Error</h3>
+  <%= json_block(@message.error) %>
+
+  <h3>Rejection</h3>
+  <%= json_block(@message.rejection) %>
+</section>

--- a/web/views/processes.erb
+++ b/web/views/processes.erb
@@ -1,0 +1,37 @@
+<section class="panel">
+  <h2>Processes</h2>
+  <%= erb(:_status_filter, statuses: SolidObjects::Web::Statistics::PROCESS_STATES, selected: @status) %>
+
+  <% if @paginator.records.empty? %>
+    <p class="empty">No process matches this filter.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr>
+          <th>Kind</th>
+          <th>Host</th>
+          <th>PID</th>
+          <th>State</th>
+          <th>Started</th>
+          <th>Last heartbeat</th>
+          <th>Activated instances</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @paginator.records.each do |process_record| %>
+          <tr>
+            <td><%= h(process_record.kind) %></td>
+            <td><%= h(process_record.hostname) %></td>
+            <td><%= h(process_record.pid) %></td>
+            <td><%= status_label(process_record.shutdown_state) %></td>
+            <td><%= relative_time(process_record.started_at) %></td>
+            <td><%= relative_time(process_record.last_heartbeat_at) %></td>
+            <td><%= number(@activated_counts.fetch(process_record.id, 0)) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <%= erb(:_paging) %>
+</section>

--- a/web/views/reminders.erb
+++ b/web/views/reminders.erb
@@ -1,0 +1,37 @@
+<section class="panel">
+  <h2>Reminders</h2>
+  <%= erb(:_status_filter, statuses: SolidObjects::Web::Statistics::REMINDER_STATUSES, selected: @status) %>
+
+  <% if @paginator.records.empty? %>
+    <p class="empty">No reminder matches this filter.</p>
+  <% else %>
+    <table>
+      <thead>
+        <tr>
+          <th>Actor</th>
+          <th>Name</th>
+          <th>Operation</th>
+          <th>Status</th>
+          <th>Next run</th>
+          <th>Interval</th>
+          <th>Occurrence</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @paginator.records.each do |reminder| %>
+          <tr>
+            <td><a href="<%= h(path_to("/instances/#{reminder.instance_id}")) %>"><%= actor_label(reminder) %></a></td>
+            <td><%= h(reminder.name) %></td>
+            <td><%= h(reminder.operation) %></td>
+            <td><%= status_label(reminder.status) %></td>
+            <td><%= relative_time(reminder.next_run_at) %></td>
+            <td><%= duration(reminder.interval_seconds) %></td>
+            <td><%= number(reminder.occurrence) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <%= erb(:_paging) %>
+</section>


### PR DESCRIPTION
`SolidObjects::Web` is a mountable Rack dashboard over the runtime tables:
instances and their committed state, the ready and claimed mailbox, reminders,
effects, broadcasts, dead letters, and processes.

```ruby
# config/routes.rb
require "solid_objects/web"

Rails.application.routes.draw do
  mount SolidObjects::Web => "/solid_objects/dashboard"
end
```

It is a separate require. A worker process must not carry a web stack, and
`test/integration/load_contract_test.rb` records each new file as deliberately
deferred.

## API

New public surface: `SolidObjects::Web.call` (the Rack entry point),
`.register` for extension tabs, routes and view directories, `.use` for Rack
middleware, and `.chart_library_url` / `.chart_library_integrity`.

`rack` becomes an explicit dependency at `>= 3.1`. It already arrives with
Action Pack in every supported Rails version; the floor is stated because the
dashboard writes lowercase response headers, which Rack 3 requires. The `web/`
directory is added to the gemspec file list.

No migration. Nothing in the runtime path changed.

## Security

Every route declares the administration policy it needs, and `Router#route`
raises at load time on a route without one. A page added later therefore cannot
reach the actor tables before an application has said who may read it, so the
deny-by-default posture is enforced by construction rather than by remembering
a filter. An unconfigured mount returns 403 everywhere.

`authorization_context:` is the request object, which answers `request`,
`session` and `env`, so a policy can read the signed-in operator the way a
controller does. `docs/dashboard.md` lists the action and resource of every
page.

Other boundaries:

- CSRF: a masked per-request token in the Rack session; a state changing
  request without a valid one gets 403.
- CSP: `default-src 'self'`, a per-request nonce, and no `unsafe-inline`. The
  Chart.js CDN host is the only external origin named, and only when charts are
  enabled. Chart data travels in a `data-` attribute, not an inline script.
- Every application supplied string is escaped, including chart data, where an
  actor type would otherwise close the attribute.
- The page size is clamped, because page and page size both arrive from the
  query string.
- Actor id filtering goes through Arel `matches` with `sanitize_sql_like`.
- Brakeman stays warning free.

## Correctness

Two write actions, both narrow:

- **Retry a dead letter** goes through `DeadLetterManager`, so it is idempotent.
  A retry the mailbox refuses, such as an actor class that no longer exists,
  renders the reason with 422 rather than failing the request.
- **Pause an instance** sets `paused_at`, which the activation manager already
  honours. This is an operator brake, not a stop: a pass already in flight
  finishes its turn, and a synchronous caller waiting on a paused instance
  times out rather than receiving a result. Both are stated on the page and in
  the docs.

Not included: bulk retry, because `DeadLetterManager` exposes no bulk
operation, and audit records of who pressed what. `docs/roadmap.md` records
both.

## Cost

The summary bar issues one grouped count per subsystem on every page, and each
list page counts its own relation to page it. Instance counts per actor type
are one grouped query on the dashboard only, bounded to twelve rows. Actor type
suggestions come from the registry rather than a `DISTINCT` no adapter can
answer from an index. Process rows count activated instances in one grouped
query rather than one per row. `HEAD /` exists so an uptime monitor need not
load a whole page. The roadmap records that this was reasoned about rather than
benchmarked.

## Validation

```
bundle exec rake          # 499 runs, 1697 assertions, 0 failures, 14 skips
npm test                  # 39 tests, 0 failures
```

`rake` covers Minitest, Standard Ruby, RuboCop, RBS generation and validation,
Steep, and Brakeman; all clean. The 14 skips are the pre-existing PostgreSQL
and MySQL suites that skip on SQLite; this change adds none.

Coverage worth naming:

- `test/integration/web_mount_test.rb` drives the dashboard through a **real
  Rails router** in a subprocess, not a mock environment: the mount supplies
  `SCRIPT_NAME`, the Rails session middleware supplies the session CSRF needs,
  and a dashboard nested below the engine mount is only reachable because the
  engine cascades a path it does not serve. It asserts a forged token is
  refused and changes nothing, and that a valid one redirects to the
  mount-prefixed path and applies the write.
- Browser modules run under jsdom, including that the poller and the server
  format the same number identically.

Every significant behaviour was mutation tested: authorization, CSRF, HTML
escaping, pause, retry, filtering, paging, formatting, chart data and the chart
container each fail when the implementation is removed.

Three defects were found this way and fixed:

1. A template compiled before an extension registered its views kept winning,
   so a replacement page was unreachable.
2. Middleware added after the first request was silently dropped, because the
   built stack is memoized.
3. A retry for a deregistered actor class raised out of the Rack handler as a
   bare 500.

## Not verified

A chart that grows on repeated redraws was reported during development. The
canvas is now in a dedicated sized container with `position: absolute`, which
is what Chart.js requires and makes the resize feedback loop structurally
impossible. I could not reproduce the original growth headlessly at
`devicePixelRatio: 2` over 60 resize and update rounds, so the fix is
structural rather than confirmed against a reproduction.
