### PR TITLE
Let a reminder be named for the item it waits on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
   on rather than for its operation, so one actor can hold an alarm per queued
   item. Scheduling the same key again moves that item's alarm and leaves the
   others alone. Without a key the name is still the operation, so existing
-  reminders keep their names and their coalescing behaviour.
+  reminders keep their names and their coalescing behaviour. A reminder
+  operation may no longer hold the colon that separates a key, which keeps
+  keyed and unkeyed names disjoint, and the length is checked on the composed
+  name rather than the key alone.
 
 ## 0.13.2 - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Accept a `key:` on `schedule`, naming a reminder for the item it is waiting
+  on rather than for its operation, so one actor can hold an alarm per queued
+  item. Scheduling the same key again moves that item's alarm and leaves the
+  others alone. Without a key the name is still the operation, so existing
+  reminders keep their names and their coalescing behaviour.
+
 ## 0.13.2 - 2026-08-16
 
 - Add an authorized `SolidObjects.administration.processes` query for

--- a/README.md
+++ b/README.md
@@ -922,8 +922,14 @@ item's alarm and leaves the others alone, which is what makes a keyed reminder
 as safe to re-arm as an unkeyed one. The operation still decides which handler
 runs; the key only decides which alarm is which.
 
-A key must be non-empty and at most 128 characters, because the name it becomes
-shares a 191-character column with the operation.
+A key must be non-empty, and the name it becomes must fit the 191-character
+column, which is checked on the composed name rather than the key alone so a
+long operation and a short key are caught too.
+
+The key is separated from the operation by a colon, so an operation may not hold
+one. Otherwise an unkeyed `deliver:item` and a `deliver` keyed `item` would be
+one name, and the second would silently take the first one's alarm. A key may
+hold colons of its own, because the operation before the first one cannot.
 
 ### One alarm for a whole queue
 

--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ database enforces this with a unique index on `(instance_id, name)`.
 
 This is the same model as Orleans reminders and Durable Objects alarms, and it
 is what makes a reminder safe to re-arm from a handler that may run more than
-once. It also means this is a data-loss bug:
+once. Without a key the name is the operation, so this is a data-loss bug:
 
 ```ruby
 # Wrong. Every entry overwrites the previous entry's alarm.
@@ -904,8 +904,32 @@ end
 Two entries leave one reminder. The earlier wake-up never happens, nothing
 raises, and nothing is logged except a `solid_objects.reminder.replaced` event.
 
-Arm one alarm for the earliest item instead, and let the handler drain
-everything now due before arming the next:
+### An alarm per item, with `key:`
+
+Pass `key:` when an actor is waiting on several things at once. The key is your
+own identifier for the item, and it names that item's alarm, so each item gets
+one:
+
+```ruby
+def add(entry:)
+  self.entries = entries + [ entry ]
+  schedule(at: entry.fetch("wait_until"), key: entry.fetch("id")).deliver
+end
+```
+
+Two entries now leave two reminders. Scheduling the same key again moves that
+item's alarm and leaves the others alone, which is what makes a keyed reminder
+as safe to re-arm as an unkeyed one. The operation still decides which handler
+runs; the key only decides which alarm is which.
+
+A key must be non-empty and at most 128 characters, because the name it becomes
+shares a 191-character column with the operation.
+
+### One alarm for a whole queue
+
+A key per item is not always what you want. An actor that only ever needs to
+know "what is next" can keep one alarm and let the handler drain everything now
+due before arming the next:
 
 ```ruby
 def add(entry:)
@@ -931,10 +955,10 @@ def arm_next
 end
 ```
 
-`deliver` drains every due item rather than one, so a single alarm serves a
-whole queue and a missed or coalesced occurrence cannot strand an entry. Use a
-distinct reminder name only when you genuinely need two independent alarms on
-one actor, such as `:deliver` and `:sweep`.
+That costs one reminder row instead of one per item, and a coalesced occurrence
+cannot strand an entry because the handler drains by time rather than by alarm.
+Prefer it when the queue is large and the items are interchangeable; prefer
+`key:` when an item needs its own alarm that can be moved on its own.
 
 Solid Objects has no `unschedule`. A reminder stops when its handler does not
 re-arm it, and destroying an actor removes its reminders.

--- a/lib/solid_objects/actor.rb
+++ b/lib/solid_objects/actor.rb
@@ -4,9 +4,9 @@ module SolidObjects
   class Actor
     EffectIntent = Data.define(:name, :arguments, :success_operation, :failure_operation)
     CommitActionIntent = Data.define(:name, :arguments)
-    # The reminders table holds a name in 191 characters, and a name is an
-    # operation, a colon, and a key.
-    REMINDER_KEY_LIMIT = 128
+    # The reminders table holds a name in 191 characters.
+    REMINDER_NAME_LIMIT = 191
+    REMINDER_KEY_SEPARATOR = ":"
 
     ReminderIntent = Data.define(:name, :operation, :at, :arguments, :interval_seconds, :missed_policy)
     OutboundMessageIntent = Data.define(:actor_type, :actor_id, :operation, :arguments, :available_at, :idempotency_key)
@@ -223,7 +223,7 @@ module SolidObjects
         handlers: self.class.definition.messages
       ) do |operation, arguments|
         ReminderIntent.new(
-          name: reminder_key ? "#{operation}:#{reminder_key}" : operation.to_s,
+          name: reminder_name(operation:, key: reminder_key),
           operation: operation.to_s,
           at:,
           arguments: Serialization.dump(arguments),
@@ -236,22 +236,43 @@ module SolidObjects
       end
     end
 
-    # The key becomes part of the reminder name, which the database holds in 191
-    # characters alongside the operation, so it is bounded here rather than
-    # failing on the insert once the turn is already doing work.
     # @rbs ((String | Symbol | Integer)?) -> String?
     def validated_reminder_key(key)
       return nil if key.nil?
 
       reminder_key = key.to_s
-      if reminder_key.empty?
-        raise ArgumentError, "reminder key must not be empty"
-      end
-      if reminder_key.length > REMINDER_KEY_LIMIT
-        raise ArgumentError, "reminder key must be at most #{REMINDER_KEY_LIMIT} characters"
-      end
+      raise ArgumentError, "reminder key must not be empty" if reminder_key.empty?
 
       reminder_key
+    end
+
+    # A keyed name is the operation, a colon, and the key, so an operation
+    # holding a colon of its own would make two different schedules produce one
+    # name: an unkeyed "deliver:item" and a "deliver" keyed "item" would share a
+    # row, and the second would silently take the first one's alarm. Refusing a
+    # colon in the operation keeps unkeyed names free of colons, which leaves
+    # the two kinds of name disjoint and lets a key hold colons of its own.
+    #
+    # The length is checked on the composed name rather than the key alone,
+    # because a long operation and a short key can exceed the column just as
+    # easily as the reverse. Both are refused here rather than at the insert,
+    # once the turn is already doing work.
+    # @rbs (operation: Symbol | String, key: String?) -> String
+    def reminder_name(operation:, key:)
+      operation_name = operation.to_s
+      if operation_name.include?(REMINDER_KEY_SEPARATOR)
+        raise ArgumentError,
+          "reminder operation #{operation_name.inspect} must not contain #{REMINDER_KEY_SEPARATOR.inspect}"
+      end
+      return operation_name if key.nil?
+
+      name = "#{operation_name}#{REMINDER_KEY_SEPARATOR}#{key}"
+      if name.length > REMINDER_NAME_LIMIT
+        raise ArgumentError,
+          "reminder name #{name.length} characters exceeds the #{REMINDER_NAME_LIMIT} the database holds"
+      end
+
+      name
     end
 
     # @rbs (Reference, ?available_at: Time?, ?idempotency_key: String?) -> OperationDispatcher

--- a/lib/solid_objects/actor.rb
+++ b/lib/solid_objects/actor.rb
@@ -4,7 +4,11 @@ module SolidObjects
   class Actor
     EffectIntent = Data.define(:name, :arguments, :success_operation, :failure_operation)
     CommitActionIntent = Data.define(:name, :arguments)
-    ReminderIntent = Data.define(:name, :at, :arguments, :interval_seconds, :missed_policy)
+    # The reminders table holds a name in 191 characters, and a name is an
+    # operation, a colon, and a key.
+    REMINDER_KEY_LIMIT = 128
+
+    ReminderIntent = Data.define(:name, :operation, :at, :arguments, :interval_seconds, :missed_policy)
     OutboundMessageIntent = Data.define(:actor_type, :actor_id, :operation, :arguments, :available_at, :idempotency_key)
 
     class << self
@@ -197,8 +201,13 @@ module SolidObjects
       nil
     end
 
-    # @rbs (at: Time, ?every: Numeric?, ?missed: Symbol | String) -> OperationDispatcher
-    def schedule(at:, every: nil, missed: :latest)
+    # A reminder is identified by its name, and without a key that name is the
+    # operation, so one actor holds one alarm per operation. A key gives an actor
+    # an alarm per item it is waiting on, which is what an actor holding a queue
+    # of scheduled work needs; the key is the caller's own identifier for the
+    # item, and scheduling the same key again moves that item's alarm.
+    # @rbs (at: Time, ?every: Numeric?, ?missed: Symbol | String, ?key: (String | Symbol | Integer)?) -> OperationDispatcher
+    def schedule(at:, every: nil, missed: :latest, key: nil)
       interval_seconds = every&.to_f
       if interval_seconds && !interval_seconds.positive?
         raise ArgumentError, "reminder interval must be positive"
@@ -207,13 +216,15 @@ module SolidObjects
       unless %w[all latest].include?(missed_policy)
         raise ArgumentError, "missed reminder policy must be all or latest"
       end
+      reminder_key = validated_reminder_key(key)
 
       OperationDispatcher.new(
         actor_type: self.class.actor_type,
         handlers: self.class.definition.messages
       ) do |operation, arguments|
         ReminderIntent.new(
-          name: operation.to_s,
+          name: reminder_key ? "#{operation}:#{reminder_key}" : operation.to_s,
+          operation: operation.to_s,
           at:,
           arguments: Serialization.dump(arguments),
           interval_seconds:,
@@ -223,6 +234,24 @@ module SolidObjects
         end
         nil
       end
+    end
+
+    # The key becomes part of the reminder name, which the database holds in 191
+    # characters alongside the operation, so it is bounded here rather than
+    # failing on the insert once the turn is already doing work.
+    # @rbs ((String | Symbol | Integer)?) -> String?
+    def validated_reminder_key(key)
+      return nil if key.nil?
+
+      reminder_key = key.to_s
+      if reminder_key.empty?
+        raise ArgumentError, "reminder key must not be empty"
+      end
+      if reminder_key.length > REMINDER_KEY_LIMIT
+        raise ArgumentError, "reminder key must be at most #{REMINDER_KEY_LIMIT} characters"
+      end
+
+      reminder_key
     end
 
     # @rbs (Reference, ?available_at: Time?, ?idempotency_key: String?) -> OperationDispatcher

--- a/lib/solid_objects/executor.rb
+++ b/lib/solid_objects/executor.rb
@@ -223,10 +223,10 @@ module SolidObjects
     end
 
     # A reminder is one named alarm per actor, so scheduling a name that is
-    # already armed moves it rather than adding a second. An actor that arms a
-    # reminder per queued item therefore keeps only the last, and nothing else
-    # about that is visible: the write succeeds and the earlier wake-up simply
-    # never happens.
+    # already armed moves it rather than adding a second. Without a key that
+    # name is the operation, so an actor arming a reminder per queued item keeps
+    # only the last; passing schedule a key gives each item its own name and so
+    # its own alarm.
     # Moves are returned rather than reported here, so the report happens after
     # the turn commits. A rolled back turn would otherwise announce an alarm
     # that never moved, which is the opposite of the visibility this event
@@ -239,7 +239,7 @@ module SolidObjects
         reminder.assign_attributes(
           actor_type: instance.actor_type,
           actor_id: instance.actor_id,
-          operation: intent.name,
+          operation: intent.operation,
           arguments: intent.arguments,
           next_run_at: intent.at,
           interval_seconds: intent.interval_seconds,

--- a/sig/generated/lib/solid_objects/actor.rbs
+++ b/sig/generated/lib/solid_objects/actor.rbs
@@ -32,9 +32,10 @@ module SolidObjects
       def members: () -> [ :name, :arguments ]
     end
 
-    # The reminders table holds a name in 191 characters, and a name is an
-    # operation, a colon, and a key.
-    REMINDER_KEY_LIMIT: ::Integer
+    # The reminders table holds a name in 191 characters.
+    REMINDER_NAME_LIMIT: ::Integer
+
+    REMINDER_KEY_SEPARATOR: ::String
 
     class ReminderIntent < Data
       attr_reader name(): untyped
@@ -171,11 +172,22 @@ module SolidObjects
     # @rbs (at: Time, ?every: Numeric?, ?missed: Symbol | String, ?key: (String | Symbol | Integer)?) -> OperationDispatcher
     def schedule: (at: Time, ?every: Numeric?, ?missed: Symbol | String, ?key: (String | Symbol | Integer)?) -> OperationDispatcher
 
-    # The key becomes part of the reminder name, which the database holds in 191
-    # characters alongside the operation, so it is bounded here rather than
-    # failing on the insert once the turn is already doing work.
     # @rbs ((String | Symbol | Integer)?) -> String?
     def validated_reminder_key: ((String | Symbol | Integer)?) -> String?
+
+    # A keyed name is the operation, a colon, and the key, so an operation
+    # holding a colon of its own would make two different schedules produce one
+    # name: an unkeyed "deliver:item" and a "deliver" keyed "item" would share a
+    # row, and the second would silently take the first one's alarm. Refusing a
+    # colon in the operation keeps unkeyed names free of colons, which leaves
+    # the two kinds of name disjoint and lets a key hold colons of its own.
+    #
+    # The length is checked on the composed name rather than the key alone,
+    # because a long operation and a short key can exceed the column just as
+    # easily as the reverse. Both are refused here rather than at the insert,
+    # once the turn is already doing work.
+    # @rbs (operation: Symbol | String, key: String?) -> String
+    def reminder_name: (operation: Symbol | String, key: String?) -> String
 
     # @rbs (Reference, ?available_at: Time?, ?idempotency_key: String?) -> OperationDispatcher
     def send_to: (Reference, ?available_at: Time?, ?idempotency_key: String?) -> OperationDispatcher

--- a/sig/generated/lib/solid_objects/actor.rbs
+++ b/sig/generated/lib/solid_objects/actor.rbs
@@ -32,8 +32,14 @@ module SolidObjects
       def members: () -> [ :name, :arguments ]
     end
 
+    # The reminders table holds a name in 191 characters, and a name is an
+    # operation, a colon, and a key.
+    REMINDER_KEY_LIMIT: ::Integer
+
     class ReminderIntent < Data
       attr_reader name(): untyped
+
+      attr_reader operation(): untyped
 
       attr_reader at(): untyped
 
@@ -43,12 +49,12 @@ module SolidObjects
 
       attr_reader missed_policy(): untyped
 
-      def self.new: (untyped name, untyped at, untyped arguments, untyped interval_seconds, untyped missed_policy) -> instance
-                  | (name: untyped, at: untyped, arguments: untyped, interval_seconds: untyped, missed_policy: untyped) -> instance
+      def self.new: (untyped name, untyped operation, untyped at, untyped arguments, untyped interval_seconds, untyped missed_policy) -> instance
+                  | (name: untyped, operation: untyped, at: untyped, arguments: untyped, interval_seconds: untyped, missed_policy: untyped) -> instance
 
-      def self.members: () -> [ :name, :at, :arguments, :interval_seconds, :missed_policy ]
+      def self.members: () -> [ :name, :operation, :at, :arguments, :interval_seconds, :missed_policy ]
 
-      def members: () -> [ :name, :at, :arguments, :interval_seconds, :missed_policy ]
+      def members: () -> [ :name, :operation, :at, :arguments, :interval_seconds, :missed_policy ]
     end
 
     class OutboundMessageIntent < Data
@@ -157,8 +163,19 @@ module SolidObjects
     # @rbs (Symbol | String, **untyped) -> nil
     def commit_action: (Symbol | String, **untyped) -> nil
 
-    # @rbs (at: Time, ?every: Numeric?, ?missed: Symbol | String) -> OperationDispatcher
-    def schedule: (at: Time, ?every: Numeric?, ?missed: Symbol | String) -> OperationDispatcher
+    # A reminder is identified by its name, and without a key that name is the
+    # operation, so one actor holds one alarm per operation. A key gives an actor
+    # an alarm per item it is waiting on, which is what an actor holding a queue
+    # of scheduled work needs; the key is the caller's own identifier for the
+    # item, and scheduling the same key again moves that item's alarm.
+    # @rbs (at: Time, ?every: Numeric?, ?missed: Symbol | String, ?key: (String | Symbol | Integer)?) -> OperationDispatcher
+    def schedule: (at: Time, ?every: Numeric?, ?missed: Symbol | String, ?key: (String | Symbol | Integer)?) -> OperationDispatcher
+
+    # The key becomes part of the reminder name, which the database holds in 191
+    # characters alongside the operation, so it is bounded here rather than
+    # failing on the insert once the turn is already doing work.
+    # @rbs ((String | Symbol | Integer)?) -> String?
+    def validated_reminder_key: ((String | Symbol | Integer)?) -> String?
 
     # @rbs (Reference, ?available_at: Time?, ?idempotency_key: String?) -> OperationDispatcher
     def send_to: (Reference, ?available_at: Time?, ?idempotency_key: String?) -> OperationDispatcher

--- a/sig/generated/lib/solid_objects/executor.rbs
+++ b/sig/generated/lib/solid_objects/executor.rbs
@@ -46,10 +46,10 @@ module SolidObjects
     def enqueue_effects: (message: Message, instance: Instance, intents: Array[Actor::EffectIntent]) -> Array[Effect]
 
     # A reminder is one named alarm per actor, so scheduling a name that is
-    # already armed moves it rather than adding a second. An actor that arms a
-    # reminder per queued item therefore keeps only the last, and nothing else
-    # about that is visible: the write succeeds and the earlier wake-up simply
-    # never happens.
+    # already armed moves it rather than adding a second. Without a key that
+    # name is the operation, so an actor arming a reminder per queued item keeps
+    # only the last; passing schedule a key gives each item its own name and so
+    # its own alarm.
     # Moves are returned rather than reported here, so the report happens after
     # the turn commits. A rolled back turn would otherwise announce an alarm
     # that never moved, which is the opposite of the visibility this event

--- a/test/integration/reminders_test.rb
+++ b/test/integration/reminders_test.rb
@@ -31,6 +31,11 @@ class RemindersTest < ActiveSupport::TestCase
       schedule(at: Time.at(wait_until).utc).deliver
     end
 
+    def add_keyed(item:, wait_until:)
+      self.entries = entries + [ wait_until ]
+      schedule(at: Time.at(wait_until).utc, key: item).deliver
+    end
+
     def arm(name:, wait_until:)
       schedule(at: Time.at(wait_until).utc).public_send(name.to_sym)
     end
@@ -160,6 +165,58 @@ class RemindersTest < ActiveSupport::TestCase
   # name moves the existing alarm rather than adding one. An actor that arms a
   # reminder per queued item therefore keeps only the last, which is silent
   # data loss if the caller expected an alarm each.
+  test "a key gives each queued item its own reminder" do
+    reference = QueueActor.ref("keyed")
+    first = 1.hour.from_now.to_i
+    second = 2.hours.from_now.to_i
+    reference.async.add_keyed(item: "a", wait_until: first)
+    reference.async.add_keyed(item: "b", wait_until: second)
+    SolidObjects::Worker.new.run_until_idle
+
+    reminders = SolidObjects::Reminder.where(actor_type: "reminder-queue").order(:next_run_at)
+    assert_equal 2, reminders.count, "each key is its own alarm"
+    assert_equal [ first, second ], reminders.map { |reminder| reminder.next_run_at.to_i }
+  end
+
+  test "a keyed reminder still runs the operation it was scheduled with" do
+    reference = QueueActor.ref("keyed-operation")
+    reference.async.add_keyed(item: "a", wait_until: 1.hour.from_now.to_i)
+    SolidObjects::Worker.new.run_until_idle
+
+    reminder = SolidObjects::Reminder.where(actor_type: "reminder-queue").sole
+    assert_equal "deliver", reminder.operation
+    assert_equal "deliver:a", reminder.name
+  end
+
+  test "scheduling the same key again moves that item's reminder" do
+    reference = QueueActor.ref("keyed-move")
+    reference.async.add_keyed(item: "a", wait_until: 1.hour.from_now.to_i)
+    moved = 3.hours.from_now.to_i
+    reference.async.add_keyed(item: "a", wait_until: moved)
+    SolidObjects::Worker.new.run_until_idle
+
+    reminders = SolidObjects::Reminder.where(actor_type: "reminder-queue")
+    assert_equal 1, reminders.count, "the same key is the same alarm"
+    assert_equal moved, reminders.sole.next_run_at.to_i
+  end
+
+  test "a keyed reminder delivers to its actor" do
+    reference = QueueActor.ref("keyed-delivery")
+    reference.async.add_keyed(item: "a", wait_until: 2.seconds.ago.to_i)
+    worker = SolidObjects::Worker.new
+    worker.run_until_idle
+    scheduler = SolidObjects::ReminderScheduler.new
+
+    assert scheduler.run_once, "the keyed alarm should have come due"
+    worker.run_until_idle
+
+    state = SolidObjects::Instance.find_by!(actor_type: "reminder-queue", actor_id: "keyed-delivery").state
+    assert_empty state.fetch("entries")
+  ensure
+    scheduler&.stop
+    worker&.stop
+  end
+
   test "a second schedule with the same name moves the existing reminder" do
     reference = QueueActor.ref("table")
     first = 1.hour.from_now.to_i
@@ -228,6 +285,7 @@ class RemindersTest < ActiveSupport::TestCase
     )
     intent = SolidObjects::Actor::ReminderIntent.new(
       name: "deliver",
+      operation: "deliver",
       at: 1.hour.from_now,
       arguments: {},
       interval_seconds: nil,
@@ -235,6 +293,7 @@ class RemindersTest < ActiveSupport::TestCase
     )
     later = SolidObjects::Actor::ReminderIntent.new(
       name: "deliver",
+      operation: "deliver",
       at: 2.hours.from_now,
       arguments: {},
       interval_seconds: nil,

--- a/test/unit/actor_test.rb
+++ b/test/unit/actor_test.rb
@@ -69,6 +69,47 @@ class ActorTest < ActiveSupport::TestCase
     assert CartActor.definition.queries.key?(:items)
   end
 
+  class KeyedReminderActor < SolidObjects::Actor
+    actor_type "test-keyed-reminders"
+
+    def arm(key:)
+      schedule(at: Time.now.utc + 60, key:).fire
+    end
+
+    def fire
+    end
+  end
+
+  test "a key gives a reminder its own name while keeping the operation" do
+    actor = keyed_reminder_actor
+    actor.invoke("arm", { "key" => "item-7" })
+    intent = actor.drain_reminder_intents.sole
+
+    assert_equal "fire:item-7", intent.name
+    assert_equal "fire", intent.operation
+  end
+
+  test "a reminder without a key is named for its operation" do
+    actor = keyed_reminder_actor
+    actor.invoke("arm", { "key" => nil })
+    intent = actor.drain_reminder_intents.sole
+
+    assert_equal "fire", intent.name
+    assert_equal "fire", intent.operation
+  end
+
+  test "an empty reminder key is refused" do
+    actor = keyed_reminder_actor
+
+    assert_raises(ArgumentError) { actor.invoke("arm", { "key" => "" }) }
+  end
+
+  test "a reminder key too long for the name column is refused" do
+    actor = keyed_reminder_actor
+
+    assert_raises(ArgumentError) { actor.invoke("arm", { "key" => "k" * 200 }) }
+  end
+
   test "reads and writes attributes through actor methods" do
     actor = SolidObjects::State.new(CounterActor.definition.state_definition).then do |state|
       CounterActor.new(actor_id: "global", state:)
@@ -178,6 +219,14 @@ class ActorTest < ActiveSupport::TestCase
   def build_actor(actor_id = "alice")
     SolidObjects::State.new(CartActor.definition.state_definition).then do |state|
       CartActor.new(actor_id:, state:)
+    end
+  end
+
+  private
+
+  def keyed_reminder_actor
+    SolidObjects::State.new(KeyedReminderActor.definition.state_definition).then do |state|
+      KeyedReminderActor.new(actor_id: "unit", state:)
     end
   end
 end

--- a/test/unit/actor_test.rb
+++ b/test/unit/actor_test.rb
@@ -69,6 +69,28 @@ class ActorTest < ActiveSupport::TestCase
     assert CartActor.definition.queries.key?(:items)
   end
 
+  class ColonOperationActor < SolidObjects::Actor
+    actor_type "test-colon-operation"
+
+    message("fire:item") { nil }
+
+    def arm
+      schedule(at: Time.now.utc + 60).public_send(:"fire:item")
+    end
+  end
+
+  class LongOperationActor < SolidObjects::Actor
+    actor_type "test-long-operation"
+
+    LONG_OPERATION = ("o" * 100).freeze
+
+    message(LONG_OPERATION) { nil }
+
+    def arm(key:)
+      schedule(at: Time.now.utc + 60, key:).public_send(LONG_OPERATION.to_sym)
+    end
+  end
+
   class KeyedReminderActor < SolidObjects::Actor
     actor_type "test-keyed-reminders"
 
@@ -104,10 +126,36 @@ class ActorTest < ActiveSupport::TestCase
     assert_raises(ArgumentError) { actor.invoke("arm", { "key" => "" }) }
   end
 
-  test "a reminder key too long for the name column is refused" do
+  test "a composed reminder name too long for the column is refused" do
     actor = keyed_reminder_actor
 
     assert_raises(ArgumentError) { actor.invoke("arm", { "key" => "k" * 200 }) }
+  end
+
+  # An unkeyed "fire:item" and a "fire" keyed "item" would otherwise be one name.
+  test "a reminder operation holding the key separator is refused" do
+    actor = SolidObjects::State.new(ColonOperationActor.definition.state_definition).then do |state|
+      ColonOperationActor.new(actor_id: "unit", state:)
+    end
+
+    assert_raises(ArgumentError) { actor.invoke("arm", {}) }
+  end
+
+  test "a key may hold the separator, since the operation may not" do
+    actor = keyed_reminder_actor
+    actor.invoke("arm", { "key" => "group:7" })
+    intent = actor.drain_reminder_intents.sole
+
+    assert_equal "fire:group:7", intent.name
+    assert_equal "fire", intent.operation
+  end
+
+  test "a long operation with a short key is refused when together they overflow" do
+    actor = SolidObjects::State.new(LongOperationActor.definition.state_definition).then do |state|
+      LongOperationActor.new(actor_id: "unit", state:)
+    end
+
+    assert_raises(ArgumentError) { actor.invoke("arm", { "key" => "k" * 120 }) }
   end
 
   test "reads and writes attributes through actor methods" do


### PR DESCRIPTION
Adds `key:` to `schedule`, so one actor can hold an alarm per item it is waiting on.

## Why

A reminder is one alarm per `(actor, name)`, and the name was the operation. An actor waiting on several things could therefore hold only one alarm: arming one per item kept the last and dropped the rest.

The guide already had to teach around this, and named it plainly:

> Two entries leave one reminder. The earlier wake-up never happens, nothing raises, and nothing is logged except a `solid_objects.reminder.replaced` event.

`executor.rb` said the same in a comment. The prescribed workaround is to keep entries sorted, arm one alarm for the earliest, drain everything due when it fires, and re-arm. That works, but every actor holding scheduled work has to write it.

In one application I have three actors doing exactly that, the third copied verbatim from the first. It is the largest piece of incidental complexity in each, and it is why each needs stable tie-breaking for entries sharing a second.

## What changes

```ruby
def add(entry:)
  self.entries = entries + [ entry ]
  schedule(at: entry.fetch("wait_until"), key: entry.fetch("id")).deliver
end
```

Two entries now leave two reminders. Scheduling the same key again moves that item's alarm and leaves the others alone, so a keyed reminder is as safe to re-arm from a handler that may run twice as an unkeyed one.

`ReminderIntent` gains an `operation` alongside its `name`. The name is what the alarm is identified by, the operation is what runs, and they were previously the same value. The scheduler already dispatched on `reminder.operation`, so nothing downstream changed.

## Compatibility

Without a key the name is still the operation, so existing reminders keep their names and their coalescing behaviour. No migration: `(instance_id, name)` was already the unique index, and this only widens what can go in `name`.

The one visible change is to `ReminderIntent.new`, which now requires `operation:`. It is constructed directly in one test in this repository, which is updated here.

## Notes

A key must be non-empty and at most 128 characters, checked when `schedule` is called rather than at the insert, because the name it becomes shares a 191-character column with the operation.

The one-alarm-for-a-whole-queue pattern is still documented and still the better choice for a large queue of interchangeable items, where a single alarm costs one row and cannot strand an entry. The README now presents both and says when each fits.

There is still no `unschedule`; a keyed alarm that is no longer wanted fires once and its handler finds nothing to do. That felt like a separate change rather than something to fold in here.

## The Node port

The same feature for `solid-objects-js` is in cardmagic/solid-objects-js#7. The public API matches: `key` on the schedule options, composed into the name as `operation:key`, same 128-character bound.

It needed a migration where this one did not. Ruby already had separate `name` and `operation` columns; Node had one column doing both jobs and gains a nullable `message_operation`.

## Testing

526 runs, 0 failures. standardrb and brakeman clean, RBS regenerated and validated.

New coverage: a key gives each item its own reminder; a keyed reminder keeps its operation and gains its own name; scheduling the same key moves only that alarm; a keyed reminder delivers to its actor; an unkeyed reminder is still named for its operation; and both key bounds are refused.