### PR TITLE
Say what the gem is rather than what it came from

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/cardmagic/solid_objects/actions/workflows/ci.yml/badge.svg)](https://github.com/cardmagic/solid_objects/actions/workflows/ci.yml)
 
-**Cloudflare Durable Objects, ported to Rails.**
+**Self-hosted, distributed Durable Objects in Rails without a daemon using your existing SQL database.**
 
 Solid Objects brings the Durable Objects programming model—addressable objects,
 durable state, serialized turns, alarms, and live clients—to ordinary Rails


### PR DESCRIPTION
Changes the README tagline:

> **Cloudflare Durable Objects, ported to Rails.**

to

> **Self-hosted, distributed Durable Objects in Rails without a daemon using your existing SQL database.**

The old line named where the idea came from. The new one names what someone gets: Durable Objects they host themselves, distributed, with no daemon to run and no database to add.

## One thing left alone

`solid_objects.gemspec` carries the same sentence as `spec.summary`, which is what rubygems.org shows:

```ruby
spec.summary = "Cloudflare Durable Objects, ported to Rails"
```

I left it, since changing a published package field is a bigger call than editing a README and was not part of the request. Say the word and I will match it here, or in its own change.