### PR TITLE
Put keyed reminders in the release they ship in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.13.2 - 2026-08-17
 
 - Accept a `key:` on `schedule`, naming a reminder for the item it is waiting
   on rather than for its operation, so one actor can hold an alarm per queued
@@ -10,9 +10,6 @@
   operation may no longer hold the colon that separates a key, which keeps
   keyed and unkeyed names disjoint, and the length is checked on the composed
   name rather than the key alone.
-
-## 0.13.2 - 2026-08-16
-
 - Add an authorized `SolidObjects.administration.processes` query for
   inspecting live and stale process rows through the runtime database adapter.
 - Document rolling-deployment overlap as a reason for the polling-only warning.


### PR DESCRIPTION
Folds the `Unreleased` changelog entry into `0.13.2` and dates it for the day it goes out.

## Why

`0.13.2` has a changelog section and `version.rb` already says `0.13.2`, but it was never published — rubygems is still on `0.13.1`. Keyed reminders then landed and went under `Unreleased`, above a release that had not happened.

Read from the outside that says 0.13.2 shipped and keyed reminders are waiting for something later, when in fact they go out together.

```
## Unreleased          ->    ## 0.13.2 - 2026-08-17
- keyed reminders            - keyed reminders
                             - process administration
## 0.13.2 - 2026-08-16       - rolling-deployment docs
- process administration
- rolling-deployment docs
```

No version bump: `version.rb` is already `0.13.2` and `rake build` produces `solid_objects-0.13.2.gem`.

## Manual QA on merged main

I drove keyed reminders through a real actor rather than asserting on intents, with the scheduler and worker running:

```
1. three items -> 3 alarms: ["launch:alpha", "launch:bravo", "launch:charlie"]
   operations all 'launch': ["launch"]
2. due alarms fired: 2, launched: ["alpha", "bravo"]
   pending entry kept: ["charlie"]
3. remaining armed alarm: ["launch:charlie"]
4. rescheduling one key moved only it: at=true, total alarms=3
5. a key holding colons works: true operation="launch"
```

That covers the properties the feature promises: an alarm per item, only due ones firing, the operation surviving the composed name, a re-scheduled key moving its own alarm and no other, and a key holding colons of its own.

`bundle exec rake` on main: 532 runs, 0 failures. Standard, RuboCop, Brakeman and RBS validation clean.

## Note

The matching Node release is cardmagic/solid-objects-js#9.