### PR TITLE
Support Rails 7.1 and 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: [ "3.3", "3.4", "4.0" ]
-        rails-version: [ "8.0", "8.1" ]
+        rails-version: [ "7.1", "7.2", "8.0", "8.1" ]
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Use dedicated, empty databases for adapter tests and benchmarks.
 
 ## Coding Style & Naming Conventions
 
-Target Ruby 3.3+ and Rails 8+. Use two-space indentation and let Standard Ruby plus the Solid Queue-derived RuboCop policy decide formatting. Prefer descriptive `snake_case` methods and variables, `CamelCase` constants, early returns, and keyword shorthand such as `Message.new(actor_id:)`. Avoid boolean parameters and abbreviations.
+Target Ruby 3.3+ and Rails 7.1+. Use two-space indentation and let Standard Ruby plus the Solid Queue-derived RuboCop policy decide formatting. Prefer descriptive `snake_case` methods and variables, `CamelCase` constants, early returns, and keyword shorthand such as `Message.new(actor_id:)`. Avoid boolean parameters and abbreviations.
 
 Every owned Ruby file must enable inline RBS with `# rbs_inline: enabled`; annotate methods and instance variables using `# @rbs`. Keep database behavior portable across SQLite, PostgreSQL, and MySQL. Model queue state through table membership rather than partial indexes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   `config/initializers` no longer loses them.
 - Apply the configured `connects_to` in the record class body, so the
   connection follows the class through a development reload.
+- Lower the supported Rails floor from 8.0 to 7.1. The gem dependencies, the
+  bundled migrations, and the compatibility CI matrix now cover Rails 7.1, 7.2,
+  8.0, and 8.1. The migrations declare `ActiveRecord::Migration[7.1]`, which
+  builds the same schema as `[8.0]` because the compatibility layer between the
+  two only changes `remove_foreign_key`, which no Solid Objects migration calls.
+  Rails 7.0 stays out of range: its SQLite adapter requires `sqlite3 ~> 1.4`,
+  and the busy-handler control this gem needs arrived in `sqlite3` 2.x.
 
 ## 0.13.2 - 2026-08-17
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     solid_objects (0.13.3)
-      actioncable (>= 8.0)
-      actionpack (>= 8.0)
-      actionview (>= 8.0)
-      activerecord (>= 8.0)
-      activesupport (>= 8.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      actionview (>= 7.1)
+      activerecord (>= 7.1)
+      activesupport (>= 7.1)
       rack (>= 3.1)
-      railties (>= 8.0)
+      railties (>= 7.1)
       thor (>= 1.3)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -341,7 +341,8 @@ mount SolidObjects::Engine => "/solid_objects"
 
 ## Installation
 
-Solid Objects requires Ruby 3.3 or newer and Rails 8.0 or newer.
+Solid Objects requires Ruby 3.3 or newer and Rails 7.1 or newer. CI runs the
+suite against Rails 7.1, 7.2, 8.0, and 8.1.
 
 Add the gem, install its initializer and migration, then migrate:
 

--- a/db/migrate/20260805000000_create_solid_objects_tables.rb
+++ b/db/migrate/20260805000000_create_solid_objects_tables.rb
@@ -1,6 +1,6 @@
 # rbs_inline: enabled
 
-class CreateSolidObjectsTables < ActiveRecord::Migration[8.0]
+class CreateSolidObjectsTables < ActiveRecord::Migration[7.1]
   # @rbs () -> void
   def change
     create_processes

--- a/db/migrate/20260806000000_add_state_revision_to_solid_objects_instances.rb
+++ b/db/migrate/20260806000000_add_state_revision_to_solid_objects_instances.rb
@@ -1,6 +1,6 @@
 # rbs_inline: enabled
 
-class AddStateRevisionToSolidObjectsInstances < ActiveRecord::Migration[8.0]
+class AddStateRevisionToSolidObjectsInstances < ActiveRecord::Migration[7.1]
   # @rbs () -> void
   def change
     add_column SolidObjects.table_name(:instances),

--- a/db/migrate/20260813000000_rename_message_dispatch_columns.rb
+++ b/db/migrate/20260813000000_rename_message_dispatch_columns.rb
@@ -1,6 +1,6 @@
 # rbs_inline: enabled
 
-class RenameMessageDispatchColumns < ActiveRecord::Migration[8.0]
+class RenameMessageDispatchColumns < ActiveRecord::Migration[7.1]
   # @rbs () -> void
   def up
     remove_check_constraint messages_table, name: "chk_so_messages_kind"

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Ruby 3.3 or newer
-- Rails 8.0 or newer
+- Rails 7.1 or newer
 - SQLite 3.35+, PostgreSQL 14+, and MySQL 8.0/InnoDB for the full matrix
 
 Install dependencies:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,8 +66,12 @@
 - Inline RBS generation/validation, Steep, Standard Ruby, Solid Queue's exact
   RuboCop policy, and a warning-free Brakeman scan
 - Compatibility CI across the supported span: Ruby 3.3, 3.4, and 4.0 against
-  Rails 8.0 and 8.1, pinned through `RAILS_VERSION` so the advertised range is
-  verified rather than assumed
+  Rails 7.1, 7.2, 8.0, and 8.1, pinned through `RAILS_VERSION` so the advertised
+  range is verified rather than assumed. The compatibility job runs SQLite only;
+  the PostgreSQL and MySQL jobs run on the newest Rails, so adapter behavior on
+  Rails 7.1 and 7.2 is unmeasured against those servers. Rails 7.0 is out of
+  range because its SQLite adapter requires `sqlite3 ~> 1.4`, and this gem needs
+  the busy-handler control that arrived in `sqlite3` 2.x
 - A JavaScript suite covering every browser module, run in CI with Node's test
   runner and jsdom, plus a browser suite running the same modules against real
   Chromium and a real Turbo build, with every GitHub Actions reference pinned to

--- a/solid_objects.gemspec
+++ b/solid_objects.gemspec
@@ -35,16 +35,16 @@ Gem::Specification.new do |spec|
   spec.executables = [ "solid_objects" ]
   spec.require_paths = [ "lib" ]
 
-  spec.add_dependency "actioncable", ">= 8.0"
-  spec.add_dependency "actionpack", ">= 8.0"
-  spec.add_dependency "actionview", ">= 8.0"
-  spec.add_dependency "activerecord", ">= 8.0"
-  spec.add_dependency "activesupport", ">= 8.0"
+  spec.add_dependency "actioncable", ">= 7.1"
+  spec.add_dependency "actionpack", ">= 7.1"
+  spec.add_dependency "actionview", ">= 7.1"
+  spec.add_dependency "activerecord", ">= 7.1"
+  spec.add_dependency "activesupport", ">= 7.1"
   # The operator dashboard is a Rack application. Rack arrives with Action Pack
   # in every supported Rails version; the floor is stated because the dashboard
   # writes lowercase response headers, which Rack 3 requires.
   spec.add_dependency "rack", ">= 3.1"
-  spec.add_dependency "railties", ">= 8.0"
+  spec.add_dependency "railties", ">= 7.1"
   spec.add_dependency "thor", ">= 1.3"
 
   spec.add_development_dependency "benchmark"

--- a/test/integration/enqueue_lock_retry_test.rb
+++ b/test/integration/enqueue_lock_retry_test.rb
@@ -74,7 +74,10 @@ class EnqueueLockRetryTest < ActiveSupport::TestCase
     reference = CartActor.ref("alice")
     lock = hold_write_lock
 
-    error = assert_raises(ActiveRecord::StatementTimeout) do
+    # Rails 8 maps an exhausted SQLite busy handler to StatementTimeout, and
+    # Rails 7.1 and 7.2 leave it as the StatementInvalid that timeout subclasses.
+    # The message is what the caller relies on, so it carries the assertion.
+    error = assert_raises(ActiveRecord::StatementInvalid) do
       Timeout.timeout(20) do
         SolidObjects::Record.connection_pool.with_connection do |connection|
           suspend_sqlite_busy_wait(connection) do


### PR DESCRIPTION
Adds to the untagged `0.13.3` release.

The gemspec required Rails 8.0 from the first release commit, so applications on
the two prior Rails lines could not add the gem. Measuring the suite against
those lines shows the floor was higher than the code needs.

## What the measurement showed

Full suite, SQLite, with the gemspec floor relaxed and no other change:

| Rails | Ruby  | Result                                          |
| ----- | ----- | ----------------------------------------------- |
| 7.2.3 | 3.3.9 | 532 runs, 1 failure, 15 skips                   |
| 7.1.6 | 3.3.9 | 532 runs, 1 failure, 15 skips                   |
| 7.1.6 | 4.0.5 | 532 runs, 1 failure, 15 skips                   |
| 7.0.10| 3.3.9 | cannot load: `sqlite3 ~> 1.4` conflict          |

The single failure was the same one in all three passing runs, and it asserts a
Rails 8 error class rather than a behaviour:

```
EnqueueLockRetryTest#test_a_permanently_locked_database_still_raises_rather_than_hanging
[ActiveRecord::StatementTimeout] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"SQLite3::BusyException: database is locked">
```

Rails 8 maps an exhausted SQLite busy handler to `StatementTimeout`. Rails 7.1
and 7.2 leave it as the `StatementInvalid` that `StatementTimeout` subclasses.
The library's own retry predicate walks the cause chain for
`BusyException|BusyError`, so it never depended on the Rails 8 class. The
assertion moves to the parent class and keeps the `/database is locked/` match,
which is what the caller actually relies on.

## Rails 7.0 is out of range

Its SQLite adapter requires `sqlite3 ~> 1.4`:

```
Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on?
can't activate sqlite3 (~> 1.4), already activated sqlite3-2.9.6
```

The busy-handler control this gem depends on (`busy_handler_timeout=`) arrived
in `sqlite3` 2.x, so the two cannot be loaded together. Supporting 7.0 would
mean giving up SQLite, which the gem advertises.

## Change

- Gem dependencies drop from `>= 8.0` to `>= 7.1` for `actioncable`,
  `actionpack`, `actionview`, `activerecord`, `activesupport`, and `railties`.
  `rack >= 3.1` is unchanged and still resolves on 7.1.
- The bundled migrations declare `ActiveRecord::Migration[7.1]`. `[8.0]` raises
  `Unknown migration version` on 7.x. Under Rails 8 the compatibility layer
  between `[7.1]` and `[8.0]` only changes `remove_foreign_key`, and no Solid
  Objects migration calls it, so an install built at `[7.1]` gets the same
  schema as one built at `[8.0]`.
- The compatibility CI matrix runs Ruby 3.3, 3.4, and 4.0 against Rails 7.1,
  7.2, 8.0, and 8.1.
- README, `docs/development.md`, `AGENTS.md`, `docs/roadmap.md`, and
  `CHANGELOG.md` record the new floor.

## Limitation recorded

The compatibility job runs SQLite only. The PostgreSQL and MySQL jobs run on the
newest Rails, so adapter behaviour on Rails 7.1 and 7.2 is unmeasured against
those servers. `docs/roadmap.md` states this rather than implying full coverage.

## Validation

`bundle exec rake` on Rails 8.1.3.1 / Ruby 4.0.5: 535 runs, 1768 assertions,
0 failures, 0 errors, 15 skips. Standard Ruby, RuboCop, RBS, Steep, and Brakeman
all clean. The skip count matches `main`.