### PR TITLE
docs: say where async waits with no worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- State where `async` waits when no worker runs. The `async` section of the
+  README and the runtime section of `docs/operations.md` now say that the
+  generator and the migrations start no role, so an application that serves
+  web requests alone leaves the message ready until
+  `bundle exec solid_objects start` runs the roles. The message is durable
+  and waits; it is not lost. `test/integration/background_pickup_test.rb`
+  pins it: the message reads `ready` and the actor state stays empty until a
+  worker runs. This matches solid-objects-js#22, which reported the same gap
+  for `runtime.run(signal)` in the Node package.
+
 - Add `examples/at_least_once` and `bundle exec rake at_least_once`, an
   executable proof that the at-least-once clause fires and that the
   documented remedy absorbs it. One actor turn stages an effect that writes

--- a/README.md
+++ b/README.md
@@ -662,6 +662,12 @@ message = order.async(
 ).submit
 ```
 
+`async` needs a running actor worker. Installing the engine and migrating the
+schema starts no role, so a process that only serves web requests leaves the
+message ready. Nothing is lost. The message waits until
+`bundle exec solid_objects start` runs the roles. See
+[Worker requirements](#worker-requirements) for the feature-by-role table.
+
 Use `available_at:` to spread bulk work or delay one message:
 
 ```ruby

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -31,6 +31,13 @@ Start all configured roles:
 bundle exec solid_objects start
 ```
 
+The generator and the migrations prepare the database and start nothing. A
+process claims ready messages only after this command starts its roles, so an
+application that serves web requests alone leaves every `async` message ready.
+The message is durable and waits for the first process that runs the roles. A
+direct call or an explicit `sync` needs no running role, because the caller's
+own path executes it.
+
 The command loads the host application's `app/actors` directories before
 starting any runtime role, even when Rails eager loading is disabled. Actors in
 the conventional directory do not need initializer references. The targeted

--- a/test/integration/background_pickup_test.rb
+++ b/test/integration/background_pickup_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "database_test_helper"
+
+class BackgroundPickupTest < ActiveSupport::TestCase
+  class MailboxActor < SolidObjects::Actor
+    actor_type "background-pickup-mailbox"
+
+    attribute :delivered, default: 0
+
+    def receive
+      self.delivered += 1
+    end
+  end
+
+  test "leaves an async message ready until a worker runs the roles" do
+    message = MailboxActor.ref("inbox").async.receive
+
+    assert_equal "ready", message.status
+    assert_empty SolidObjects::Instance.find_by!(
+      actor_type: "background-pickup-mailbox", actor_id: "inbox"
+    ).state
+
+    worker = SolidObjects::Worker.new
+    begin
+      worker.run_until_idle
+    ensure
+      worker.stop
+    end
+
+    assert_equal "completed", message.status
+    assert_equal(
+      { "delivered" => 1 },
+      SolidObjects::Instance.find_by!(actor_type: "background-pickup-mailbox", actor_id: "inbox").state
+    )
+  end
+end


### PR DESCRIPTION
The Ruby counterpart of
[solid-objects-js#27](https://github.com/cardmagic/solid-objects-js/pull/27),
which closes
[solid-objects-js#22](https://github.com/cardmagic/solid-objects-js/issues/22).

## Why

The JS issue came from an external prober who built a two-process harness from
the README, watched ready messages sit unclaimed for 30 seconds, and concluded
messages were stranded. Nothing was wrong with the runtime. The page never said
that installing starts no role.

The gem is in better shape than the Node package was. `## Worker requirements`
already carries the feature-by-role table and the exact sentence a worried
reader needs:

> A missing worker never makes a durable `async` message disappear, but it
> leaves the message pending indefinitely.

What was missing is the pointer at the point of use. A reader who jumps to
`### async` from the table of contents reads only that execution is "left to
the worker fleet," which does not tell them a fleet has to exist, or what
happens meanwhile.

## What changed

**README**, in the `async` section:

> `async` needs a running actor worker. Installing the engine and migrating the
> schema starts no role, so a process that only serves web requests leaves the
> message ready. Nothing is lost. The message waits until
> `bundle exec solid_objects start` runs the roles. See Worker requirements for
> the feature-by-role table.

**docs/operations.md**, in the runtime section: the same claim, plus the
boundary that makes it make sense. A direct call or an explicit `sync` needs no
running role, because the caller's own path executes it.

## Keeping the sentence honest

`test/integration/background_pickup_test.rb` pins the documented behavior:

```ruby
message = MailboxActor.ref("inbox").async.receive

assert_equal "ready", message.status
assert_empty SolidObjects::Instance.find_by!(
  actor_type: "background-pickup-mailbox", actor_id: "inbox"
).state

worker = SolidObjects::Worker.new
worker.run_until_idle

assert_equal "completed", message.status
```

A test that only ever sees `ready` proves nothing, so I checked that the first
assertion detects pickup. Running a worker before it turns the test red:

```
Failure:
BackgroundPickupTest#test_leaves_an_async_message_ready_until_a_worker_runs_the_roles:
Expected: "ready"
  Actual: "completed"
```

One detail worth recording, because it surprised me while writing the test: the
enqueue does create the instance row, since it locks the instance to allocate
the mailbox sequence. So "nothing ran yet" shows up as empty state, not as a
missing row. The first draft asserted a missing row and failed:

```
Expected #<SolidObjects::Instance id: 1, actor_type: "background-pickup-mailbox",
actor_id: "inbox", state: {}, state_version: 1, next_message_sequence: 2, ...> to be nil.
```

## Effects

- API: none.
- Correctness: none. The test asserts existing behavior.
- Security, migration, compatibility: none.

`docs/roadmap.md` is untouched, per AGENTS.md: this edits prose and adds a test
rather than moving what the project claims about itself.

## Validation

- `bundle exec rake` (test, standard, rubocop, rbs, steep, security): pass.
- Mutation check on the new test, quoted above.
